### PR TITLE
Use in-memory map to save scheduler state

### DIFF
--- a/daemon-scheduler/internal/features/integ/create_environment.feature
+++ b/daemon-scheduler/internal/features/integ/create_environment.feature
@@ -29,5 +29,4 @@ Feature: Integration tests of CreateEnvironment API
     Scenario: CreateEnvironment API should fail for empty name
         Given a cluster "ecs-daemon-scheduler-test"
         And a registered "sleep" task-definition
-        And I deregister task-definition
         When I create an environment with name " " it should fail with BadRequest

--- a/daemon-scheduler/internal/features/wrappers/ecs_wrapper.go
+++ b/daemon-scheduler/internal/features/wrappers/ecs_wrapper.go
@@ -95,9 +95,10 @@ func (ecsWrapper ECSWrapper) DeregisterTaskDefinition(taskDefnARN string) error 
 	return nil
 }
 
-func (ecsWrapper ECSWrapper) ListTasks(clusterName string) ([]*string, error) {
+func (ecsWrapper ECSWrapper) ListTasks(clusterName string, startedBy *string) ([]*string, error) {
 	in := ecs.ListTasksInput{
-		Cluster: &clusterName,
+		Cluster:   aws.String(clusterName),
+		StartedBy: startedBy,
 	}
 	resp, err := ecsWrapper.client.ListTasks(&in)
 	if err != nil {
@@ -152,7 +153,6 @@ func (ecsWrapper ECSWrapper) RegisterTaskDefinition(taskDefinition string) (stri
 	taskDefnARN, err := ecsWrapper.DescribeTaskDefinition(taskDefinition)
 	if err == nil {
 		return taskDefnARN, nil
-
 	}
 
 	name := "sleep"

--- a/daemon-scheduler/pkg/mocks/css_mocks.go
+++ b/daemon-scheduler/pkg/mocks/css_mocks.go
@@ -17,7 +17,7 @@
 package mocks
 
 import (
-	models "github.com/blox/blox/daemon-scheduler/pkg/clients/css/models"
+	"github.com/blox/blox/daemon-scheduler/pkg/clients/css/models"
 	gomock "github.com/golang/mock/gomock"
 )
 

--- a/daemon-scheduler/pkg/mocks/deployment_mocks.go
+++ b/daemon-scheduler/pkg/mocks/deployment_mocks.go
@@ -17,9 +17,10 @@
 package mocks
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	context "context"
-	types "github.com/blox/blox/daemon-scheduler/pkg/types"
+
+	"github.com/blox/blox/daemon-scheduler/pkg/types"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of Deployment interface


### PR DESCRIPTION
### Summary
Use in-memory map to save scheduler state

### Details & Implementation
Scheduler performs deployments onto configured cluster. Scheduler uses
cluster's state provided by cluster-state-service which is served by
CloudWatch Events from EC2 Container Service. However when events are
delayed cluster-state-service runs the risk of not having the
information of tasks started by scheduler in its previous run. For this
reason Scheduler needs to record its intent and then start tasks. This
intent is temporary until cluster-state-service catches up with ECS
state. This change introduces a store in the form of maps (nothing fancy).

When ECS provides idempotent way to launch tasks then we can get rid of
this local store. If not we can also think about using etcd store.

### Testing
- [X] Builds (`make release`)
- [X] Unit tests (`make unit-tests`) pass
- [X] Integration tests (`make integ-tests`) pass
- [X] Functional tests (`make e2e-tests`) pass

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes