### PR TITLE
godeps: Fix etcd revision

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -211,8 +211,8 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/clientv3/concurrency",
-			"Comment": "v3.1.0-rc.0-97-gddc94aa",
-			"Rev": "ddc94aaf9e1890fb533af62937d684f812da1493"
+			"Comment": "v3.1.0-rc.0-275-g377f19b",
+			"Rev": "377f19b0031f9c0aafe2aec28b6f9019311f52f9"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes",


### PR DESCRIPTION
#### Summary
Fixes a mismatch in etcd package revisions in the `Godeps.json` file.  A mismatch between packages in a single repository will cause `godep restore` to fail.

#### Implementation details
Ran `godep update github.com/coreos/etcd/...` with the etcd in my `GOPATH` set at `377f19b0031f9c0aafe2aec28b6f9019311f52f9`.

#### Testing
<!-- How was this tested? -->
- [x] Binary built locally and unit-tests pass (`make`)  
- [x] Build in docker succeeds (`make release`)

Note that `make` in `daemon-scheduler` fails like this:
```
touch generated/v1/swagger.json
./scripts/generate_swagger_artifacts.sh
./scripts/generate_swagger_artifacts.sh: 5: ./scripts/generate_swagger_artifacts.sh: Bad substitution
./scripts/generate_swagger_artifacts.sh: 7: cd: can't cd to //generated/v1
make: *** [generated/v1/client/operations/list_deployments_parameters.go] Error 2
```

New tests cover the changes: no

#### Description for the changelog
None

#### Licensing

This contribution is under the terms of the Apache 2.0 License: Yes

