### PR TITLE
Fix `make generate` for the daemon scheduler and cluster state service

### DIFF
--- a/cluster-state-service/handler/api/v1/swagger/swagger.json
+++ b/cluster-state-service/handler/api/v1/swagger/swagger.json
@@ -229,7 +229,7 @@
         "registeredResources",
         "remainingResources",
         "status",
-        "versionInfo",
+        "versionInfo"
       ],
       "properties": {
         "agentConnected": {
@@ -286,7 +286,7 @@
             "$ref": "#/definitions/ContainerInstance"
           }
         }
-      },
+      }
     },
     "ContainerInstanceAttribute": {
       "type": "object",
@@ -347,7 +347,7 @@
         "lastStatus",
         "overrides",
         "taskARN",
-        "taskDefinitionARN",
+        "taskDefinitionARN"
       ],
       "properties": {
         "clusterARN": {
@@ -407,7 +407,7 @@
             "$ref": "#/definitions/Task"
           }
         }
-      },
+      }
     },
     "TaskContainer": {
       "type": "object",
@@ -519,6 +519,6 @@
           "type": "string"
         }
       }
-    },
+    }
   }
 }

--- a/daemon-scheduler/generated/v1/swagger.json
+++ b/daemon-scheduler/generated/v1/swagger.json
@@ -47,7 +47,7 @@
             "type": "string",
             "description": "Deployment token",
             "required": true
-        },
+        }
     },
     "paths": {
         "/ping": {
@@ -155,7 +155,7 @@
                 "operationId": "deleteEnvironment",
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "OK"
                     },
                     "400": {
                         "description": "Bad Request",

--- a/daemon-scheduler/scripts/generate_swagger_artifacts.sh
+++ b/daemon-scheduler/scripts/generate_swagger_artifacts.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -eu
 
 # Normalize to working directory being build root (up one level from ./scripts)


### PR DESCRIPTION
#### Summary
Fixes `make generate` for the daemon scheduler so `make` actually works.

#### Implementation details
* Set the shebang to `/bin/bash` instead of `/bin/sh` so it uses Bash rather than another shell.
* Fixed invalid JSON in `swagger.json` for the daemon scheduler.
* Fixed invalid JSON in `swagger.json` for the cluster state service.

#### Testing
<!-- How was this tested? -->
- [x] Binary built locally and unit-tests pass (`make`)  
- [x] Build in docker succeeds (`make release`)

New tests cover the changes: no

#### Description for the changelog
None

#### Licensing

This contribution is under the terms of the Apache 2.0 License: Yes
