### PR TITLE
.github: Specify both binaries in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,8 +7,10 @@
 
 #### Testing
 <!-- How was this tested? -->
-- [ ] Binary built locally and unit-tests pass (`make`)  
-- [ ] Build in docker succeeds (`make release`)
+- [ ] cluster-state-service binary built locally and unit-tests pass (`cd cluster-state-service; make; cd ../`)
+- [ ] cluster-state-service build in Docker succeeds (`cd cluster-state-service; make release; cd ../`)
+- [ ] daemon-scheduler binary built locally and unit-tests pass (`cd daemon-scheduler; make; cd ../`)
+- [ ] daemon-scheduler build in Docker succeeds (`cd daemon-scheduler; make release; cd ../`)
 
 New tests cover the changes: <!-- yes|no -->
 


### PR DESCRIPTION
#### Summary
Updates the PR template

#### Implementation details
There are two separate Makefiles, added both to the template.

#### Testing
- [x] cluster-state-service binary built locally and unit-tests pass (`cd cluster-state-service; make; cd ../`)
- [x] cluster-state-service build in Docker succeeds (`cd cluster-state-service; make release; cd ../`)
- [x] daemon-scheduler binary built locally and unit-tests pass (`cd daemon-scheduler; make; cd ../`)
- [x] daemon-scheduler build in Docker succeeds (`cd daemon-scheduler; make release; cd ../`)

New tests cover the changes: no

#### Description for the changelog
None

#### Licensing

This contribution is under the terms of the Apache 2.0 License: Yes

