### PR TITLE
use v3api for etcdctl-cli by default

### DIFF
--- a/deploy/aws/conf/cloudformation_template.json
+++ b/deploy/aws/conf/cloudformation_template.json
@@ -492,6 +492,12 @@
             "Hostname": "etcd",
             "Image": "quay.io/coreos/etcd:v3.0.13",
             "Memory": "256",
+            "Environment": [
+              {
+                "Name": "ETCDCTL_API",
+                "Value": "3"
+              }
+            ],
             "Command": [
               "/usr/local/bin/etcd",
               "--data-dir", "/var/lib/etcd/data",

--- a/deploy/docker/conf/docker-compose.yml
+++ b/deploy/docker/conf/docker-compose.yml
@@ -42,6 +42,8 @@ services:
     image: "quay.io/coreos/etcd:v3.0.13"
     ports:
       - "2379:2379"
+    environment:
+      ETCDCTL_API: 3
     command: [
       "/usr/local/bin/etcd",
       "--data-dir", "/var/lib/etcd/data",


### PR DESCRIPTION
#### Summary

The API version used by the etcdctl command by default is set to 3.

#### Testing

```
$ docker-compose up -d
$ docker-compose exec etcd etcdctl version
etcdctl version: 3.0.13
API version: 3.0

$ docker-compose exec etcd etcdctl get --prefix --keys-only ecs
ecs/environment/foobar
ecs/instance/example01/arn:aws...
```

#### Licensing

This contribution is under the terms of the Apache 2.0 License: Yes
