### PR TITLE
Fix Makefiles to not generate licenses every time it builds.

### DIFF
--- a/cluster-state-service/Makefile
+++ b/cluster-state-service/Makefile
@@ -29,11 +29,12 @@ build:	$(LOCAL_BINARY)
 
 $(LOCAL_BINARY): $(SOURCES)
 	./scripts/build_binary.sh ./out
-	@echo "Built cluster state service"
+	@echo "Built Cluster State Service"
 
 .PHONY: generate
 generate: generate-models $(SOURCES)
 	PATH="$(ROOT)/scripts:${PATH}" go generate ./licenses/... ./copyright_gen/...
+	@echo "Generate licenses and copyrights"
 
 .PHONY: generate build-in-docker
 build-in-docker:

--- a/cluster-state-service/Makefile
+++ b/cluster-state-service/Makefile
@@ -17,7 +17,7 @@ LOCAL_BINARY=out/cluster-state-service
 ROOT := $(shell pwd)
 
 .PHONY: all
-all: clean build unit-tests
+all: clean generate build unit-tests
 
 .PHONY: generate-models
 generate-models:

--- a/cluster-state-service/Makefile
+++ b/cluster-state-service/Makefile
@@ -34,7 +34,7 @@ $(LOCAL_BINARY): $(SOURCES)
 .PHONY: generate
 generate: generate-models $(SOURCES)
 	PATH="$(ROOT)/scripts:${PATH}" go generate ./licenses/... ./copyright_gen/...
-	@echo "Generate licenses and copyrights"
+	@echo "Generated licenses and copyrights"
 
 .PHONY: generate build-in-docker
 build-in-docker:

--- a/daemon-scheduler/Makefile
+++ b/daemon-scheduler/Makefile
@@ -34,6 +34,11 @@ $(LOCAL_BINARY): $(SOURCES)
 	./scripts/build_binary.sh ./out
 	@echo "Built Blox Daemon Scheduler"
 
+$(SWAGGER_GEN): $(SWAGGER_SPEC)
+	./scripts/generate_swagger_artifacts.sh
+	PATH="$(ROOT)/scripts:${PATH}" go generate ./copyright_gen/...
+	@echo "Generate Swagger artifacts"
+
 .PHONY: unit-tests
 unit-tests:
 	go test -v ./pkg/...
@@ -43,13 +48,10 @@ clean:
 	rm -rf ./out $(GOINSTALL_BINARY) ||:
 	touch $(SWAGGER_SPEC)
 
-$(SWAGGER_GEN): $(SWAGGER_SPEC)
-	./scripts/generate_swagger_artifacts.sh
-	PATH="$(ROOT)/scripts:${PATH}" go generate ./licenses/... ./copyright_gen/...
-
 .PHONY: generate
 generate: $(SWAGGER_GEN) $(SOURCES)
 	PATH="$(ROOT)/scripts:${PATH}" go generate ./licenses/... ./copyright_gen/...
+	@echo "Generate licenses and copyrights"
 
 .PHONY: generate build-in-docker
 build-in-docker:

--- a/daemon-scheduler/Makefile
+++ b/daemon-scheduler/Makefile
@@ -20,7 +20,7 @@ GOINSTALL_BINARY=$(GOPATH)/bin/daemon-scheduler
 ROOT := $(shell pwd)
 
 .PHONY: all
-all: clean build unit-tests
+all: clean generate build unit-tests
 
 .PHONY: build-incr
 build-incr: generate

--- a/daemon-scheduler/Makefile
+++ b/daemon-scheduler/Makefile
@@ -36,7 +36,6 @@ $(LOCAL_BINARY): $(SOURCES)
 
 $(SWAGGER_GEN): $(SWAGGER_SPEC)
 	./scripts/generate_swagger_artifacts.sh
-	PATH="$(ROOT)/scripts:${PATH}" go generate ./copyright_gen/...
 	@echo "Generated Swagger artifacts"
 
 .PHONY: unit-tests

--- a/daemon-scheduler/Makefile
+++ b/daemon-scheduler/Makefile
@@ -37,7 +37,7 @@ $(LOCAL_BINARY): $(SOURCES)
 $(SWAGGER_GEN): $(SWAGGER_SPEC)
 	./scripts/generate_swagger_artifacts.sh
 	PATH="$(ROOT)/scripts:${PATH}" go generate ./copyright_gen/...
-	@echo "Generate Swagger artifacts"
+	@echo "Generated Swagger artifacts"
 
 .PHONY: unit-tests
 unit-tests:
@@ -51,7 +51,7 @@ clean:
 .PHONY: generate
 generate: $(SWAGGER_GEN) $(SOURCES)
 	PATH="$(ROOT)/scripts:${PATH}" go generate ./licenses/... ./copyright_gen/...
-	@echo "Generate licenses and copyrights"
+	@echo "Generated licenses and copyrights"
 
 .PHONY: generate build-in-docker
 build-in-docker:


### PR DESCRIPTION
#### Summary
Fix Makefiles to not regenerate licenses every time it builds.

#### Implementation details
_ Move regenerate script in DS Makefile from clean task to build task.
_ Remove generate licenses from regenerate script in DS Makefile.
_ Add echo messages.

#### Testing
<!-- How was this tested? -->
- [x] cluster-state-service binary built locally and unit-tests pass (`cd cluster-state-service; make; cd ../`)
- [x] cluster-state-service build in Docker succeeds (`cd cluster-state-service; make release; cd ../`)
- [x] daemon-scheduler binary built locally and unit-tests pass (`cd daemon-scheduler; make; cd ../`)
- [x] daemon-scheduler build in Docker succeeds (`cd daemon-scheduler; make release; cd ../`)

New tests cover the changes: no<!-- yes|no -->

#### Description for the changelog
Fix Makefiles to not regenerate licenses every time it builds.

#### Licensing

This contribution is under the terms of the Apache 2.0 License: Yes
