### PR TITLE
Fix gratuitous use of cat

### DIFF
--- a/cluster-state-service/scripts/license.sh
+++ b/cluster-state-service/scripts/license.sh
@@ -79,7 +79,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 "
 
-cat << EOF | tr -d '\r' > "${outputfile}"
+tr -d '\r' > "${outputfile}" << EOF 
 // Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/daemon-scheduler/scripts/license.sh
+++ b/daemon-scheduler/scripts/license.sh
@@ -79,7 +79,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 "
 
-cat << EOF | tr -d '\r' > "${outputfile}"
+tr -d '\r' > "${outputfile}" << EOF 
 // Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may


### PR DESCRIPTION
#### Summary
Fix gratuitous use of cat

#### Implementation details
Remove unnecessary use of cat in license.sh.

#### Testing
<!-- How was this tested? -->
- [x] cluster-state-service binary built locally and unit-tests pass (`cd cluster-state-service; make; cd ../`)
- [x] cluster-state-service build in Docker succeeds (`cd cluster-state-service; make release; cd ../`)
- [x] daemon-scheduler binary built locally and unit-tests pass (`cd daemon-scheduler; make; cd ../`)
- [x] daemon-scheduler build in Docker succeeds (`cd daemon-scheduler; make release; cd ../`)

New tests cover the changes: no<!-- yes|no -->

#### Description for the changelog
Fix gratuitous use of cat
<!--
Write a short summary that describes the changes in this pull request
for inclusion in changelog.
-->

#### Licensing

This contribution is under the terms of the Apache 2.0 License: Yes

#### Before merging
<!-- Run integration and end-to-end tests before merging -->
- [x] cluster-state-service end-to-end tests pass. Required setup details in cluster-state-service/internal/Readme.md
- [x] daemon-scheduler integration tests pass. Required setup details in daemon-scheduler/internal/README.md
- [x] daemon-scheduler end-to-end tests pass. Required setup details in daemon-scheduler/internal/README.md
