### PR TITLE
Fixing GetCurrentDeployment returning an error when there are no depl…

### DIFF
--- a/daemon-scheduler/pkg/deployment/deployment.go
+++ b/daemon-scheduler/pkg/deployment/deployment.go
@@ -255,7 +255,7 @@ func (d deployment) GetCurrentDeployment(ctx context.Context, environmentName st
 		}
 	}
 
-	return nil, errors.Errorf("There are no in-progress or completed deployments in environment %s", environmentName)
+	return nil, nil
 }
 
 func (d deployment) GetInProgressDeployment(ctx context.Context, environmentName string) (*types.Deployment, error) {

--- a/daemon-scheduler/pkg/deployment/deployment_test.go
+++ b/daemon-scheduler/pkg/deployment/deployment_test.go
@@ -439,6 +439,18 @@ func (suite *DeploymentTestSuite) TestGetCurrentDeploymentCompleted() {
 	assert.Exactly(suite.T(), deployment.ID, d.ID, "Expected the deployment to match the completed deployment")
 }
 
+func (suite *DeploymentTestSuite) TestGetCurrentDeploymentEmpty() {
+	suite.environmentObject.PendingDeploymentID = ""
+	suite.environmentObject.InProgressDeploymentID = ""
+	suite.environmentObject.Deployments = nil
+
+	suite.environment.EXPECT().GetEnvironment(suite.ctx, suite.environmentObject.Name).Return(suite.environmentObject, nil).Times(2)
+
+	d, err := suite.deployment.GetCurrentDeployment(suite.ctx, suite.environmentObject.Name)
+	assert.Nil(suite.T(), err, "Unexpected error when calling GetCurrentDeployment")
+	assert.Nil(suite.T(), d, "Unexpected deployment when there are no in progress or completed deployments")
+}
+
 func (suite *DeploymentTestSuite) TestGetCurrentDeploymentGetEnvironmentReturnsErrors() {
 	err := errors.New("Error getting environment")
 	suite.environment.EXPECT().GetEnvironment(suite.ctx, environmentName).Return(nil, err)

--- a/daemon-scheduler/pkg/engine/dispatcher.go
+++ b/daemon-scheduler/pkg/engine/dispatcher.go
@@ -82,13 +82,13 @@ func (dispatcher *dispatcher) Start() {
 					}
 				}(event)
 			case <-dispatcher.ctx.Done():
-				log.Infof("Shutting down dispatcher")
+				log.Info("Shutting down dispatcher")
 				return
 			}
 		}
 	}()
 
-	log.Infof("Started dispatcher")
+	log.Info("Started dispatcher")
 }
 
 // Worker is actor which handles an event appropriately
@@ -146,8 +146,8 @@ func (w *worker) handleStartDeploymentEvent(ctx context.Context, event Event) er
 			deploymentEvent.Environment.Name, len(deploymentEvent.Instances))
 	}
 
-	log.Infof("Succesfully created a deployment with %s on %d instances",
-		deployment.ID, len(deploymentEvent.Instances))
+	log.Debugf("Succesfully created a deployment with %s on %d instances in environment %s",
+		deployment.ID, len(deploymentEvent.Instances), deploymentEvent.Environment.Name)
 
 	w.output <- StartDeploymentResult{
 		Deployment: *deployment,
@@ -182,7 +182,7 @@ func (w *worker) handleStopTasksEvent(ctx context.Context, event Event) error {
 		}
 		err := w.ecs.StopTask(stopTasksEvent.Cluster, task)
 		if err != nil {
-			log.Errorf("Error stopping task %s : %v", task, err)
+			log.Errorf("Error stopping task %s in cluster %s: %v", task, stopTasksEvent.Cluster, err)
 			continue
 		}
 		stoppedTasks = append(stoppedTasks, task)
@@ -190,7 +190,7 @@ func (w *worker) handleStopTasksEvent(ctx context.Context, event Event) error {
 
 	// TODO: Clear the tasks from environment
 
-	log.Infof("Successfully stopped %d tasks out of %d tasks under environment %s",
+	log.Debugf("Successfully stopped %d tasks out of %d tasks under environment %s",
 		len(stoppedTasks), len(stopTasksEvent.Tasks), stopTasksEvent.Environment.Name)
 
 	w.output <- StopTasksResult{

--- a/daemon-scheduler/pkg/engine/scheduler_test.go
+++ b/daemon-scheduler/pkg/engine/scheduler_test.go
@@ -64,7 +64,7 @@ func (suite *SchedulerTestSuite) TestRunListEnvironmentsReturnsError() {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*schedulerTickerDuration)
 	defer cancel()
 	var err error
-	err = errors.New("Error calling ListEnvironemts")
+	err = errors.New("Error calling ListEnvironments")
 	suite.environmentSvc.EXPECT().ListEnvironments(ctx).Return(nil, err)
 	events := make(chan Event)
 	scheduler := NewScheduler(ctx, events, suite.environmentSvc, suite.deploymentSvc, suite.css, suite.ecs)
@@ -73,7 +73,7 @@ func (suite *SchedulerTestSuite) TestRunListEnvironmentsReturnsError() {
 	assert.Equal(suite.T(), err, errors.Cause(schedulerErrorEvent.Error))
 
 	//next run of scheduler should occur after ticker and do the same thing
-	err = errors.New("Error calling ListEnvironemts")
+	err = errors.New("Error calling ListEnvironments")
 	suite.environmentSvc.EXPECT().ListEnvironments(ctx).Return(nil, err)
 	schedulerErrorEvent = (<-events).(SchedulerErrorEvent)
 	assert.Equal(suite.T(), err, errors.Cause(schedulerErrorEvent.Error))
@@ -108,8 +108,8 @@ func (suite *SchedulerTestSuite) TestRunGetCurrentDeploymentReturnsNil() {
 	events := make(chan Event)
 	scheduler := NewScheduler(ctx, events, suite.environmentSvc, suite.deploymentSvc, suite.css, suite.ecs)
 	scheduler.Start()
-	schedulerErrorEvent := (<-events).(SchedulerErrorEvent)
-	assert.Error(suite.T(), schedulerErrorEvent.Error, "Expecting error due to no current deployment")
+	schedulerEnvironmentEvent := (<-events).(SchedulerEnvironmentEvent)
+	assert.Equal(suite.T(), environment.Name, schedulerEnvironmentEvent.Environment.Name)
 }
 
 func (suite *SchedulerTestSuite) TestRunListInstancesReturnsError() {


### PR DESCRIPTION
…oyments and tightening up logging


#### Summary
<!-- What does this pull request do? -->
Fixes the scheduler returning an error when there are no deployments to act on. Moving logging to debug.

#### Testing
<!-- How was this tested? -->
- [x] daemon-scheduler binary built locally and unit-tests pass (`cd daemon-scheduler; make; cd ../`)
- [x] daemon-scheduler build in Docker succeeds (`cd daemon-scheduler; make release; cd ../`)

New tests cover the changes: yes

#### Licensing

This contribution is under the terms of the Apache 2.0 License: Yes

#### Before merging
<!-- Run integration and end-to-end tests before merging -->
- [x] daemon-scheduler integration tests pass. Required setup details are listed [here](https://github.com/blox/blox/blob/dev/daemon-scheduler/internal/features/README.md).
- [x] daemon-scheduler end-to-end tests pass. Required setup details are listed [here](https://github.com/blox/blox/blob/dev/daemon-scheduler/internal/features/README.md).
