### PR TITLE
Adding environment methods to add pending and in-progress deployments…

### DIFF
--- a/daemon-scheduler/pkg/deployment/deployment.go
+++ b/daemon-scheduler/pkg/deployment/deployment.go
@@ -95,7 +95,7 @@ func (d deployment) CreateDeployment(ctx context.Context,
 		return nil, err
 	}
 
-	env, err = d.environment.AddDeployment(ctx, *env, *deployment)
+	env, err = d.environment.AddPendingDeployment(ctx, *env, *deployment)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error adding deployment %v to environment %s", deployment, environmentName)
 	}
@@ -151,10 +151,11 @@ func (d deployment) CreateSubDeployment(ctx context.Context, environmentName str
 			"There is no deployment for environment with name '%s' to create a sub-deployment", environmentName)
 	}
 
-	return d.startSubDeployment(ctx, env, deployment, instanceARNs)
+	return d.startDeployment(ctx, env, deployment, instanceARNs)
 }
 
-func (d deployment) startSubDeployment(ctx context.Context, env *types.Environment, deployment *types.Deployment, instanceARNs []*string) (*types.Deployment, error) {
+//TODO: wrap in a transaction so the environment and the deployment do not get modified in between being retrieved and starting tasks
+func (d deployment) startDeployment(ctx context.Context, env *types.Environment, deployment *types.Deployment, instanceARNs []*string) (*types.Deployment, error) {
 	resp, err := d.ecs.StartTask(env.Cluster, instanceARNs, deployment.ID, deployment.TaskDefinition)
 	if err != nil {
 		return nil, errors.Wrapf(

--- a/daemon-scheduler/pkg/deployment/deployment_test.go
+++ b/daemon-scheduler/pkg/deployment/deployment_test.go
@@ -157,7 +157,7 @@ func (suite *DeploymentTestSuite) TestCreateDeploymentThereIsAnInProgressDeploym
 	suite.environmentObject.Deployments[suite.deploymentObject.ID] = *suite.deploymentObject
 
 	suite.environment.EXPECT().GetEnvironment(suite.ctx, environmentName).Return(suite.environmentObject, nil)
-	suite.environment.EXPECT().AddDeployment(suite.ctx, *suite.environmentObject, gomock.Any()).Times(0)
+	suite.environment.EXPECT().AddPendingDeployment(suite.ctx, *suite.environmentObject, gomock.Any()).Times(0)
 
 	_, err := suite.deployment.CreateDeployment(suite.ctx, environmentName, suite.environmentObject.Token)
 	assert.Error(suite.T(), err, "Expected an error when there is an in-progress deployment")
@@ -166,7 +166,7 @@ func (suite *DeploymentTestSuite) TestCreateDeploymentThereIsAnInProgressDeploym
 func (suite *DeploymentTestSuite) TestCreateDeploymentAddDeploymentFails() {
 	suite.environment.EXPECT().GetEnvironment(suite.ctx, environmentName).Return(suite.environmentObject, nil).Times(2)
 
-	suite.environment.EXPECT().AddDeployment(suite.ctx, *suite.environmentObject, gomock.Any()).Do(
+	suite.environment.EXPECT().AddPendingDeployment(suite.ctx, *suite.environmentObject, gomock.Any()).Do(
 		func(_ interface{}, _ interface{}, d types.Deployment) {
 			verifyDeployment(suite.T(), suite.deploymentObject, &d)
 		}).Return(nil, errors.New("Add deployment failed"))
@@ -178,7 +178,7 @@ func (suite *DeploymentTestSuite) TestCreateDeploymentAddDeploymentFails() {
 func (suite *DeploymentTestSuite) TestCreateDeployment() {
 	suite.environment.EXPECT().GetEnvironment(suite.ctx, environmentName).Return(suite.environmentObject, nil).Times(2)
 
-	suite.environment.EXPECT().AddDeployment(suite.ctx, *suite.environmentObject, gomock.Any()).Do(
+	suite.environment.EXPECT().AddPendingDeployment(suite.ctx, *suite.environmentObject, gomock.Any()).Do(
 		func(_ interface{}, _ interface{}, d types.Deployment) {
 			verifyDeployment(suite.T(), suite.deploymentObject, &d)
 		}).Return(suite.environmentObject, nil)

--- a/daemon-scheduler/pkg/deployment/environment_test.go
+++ b/daemon-scheduler/pkg/deployment/environment_test.go
@@ -329,14 +329,14 @@ func (suite *EnvironmentTestSuite) TestFilterEnvironmentsByClusterInvalidCluster
 func (suite *EnvironmentTestSuite) TestAddDeploymentEmptyDeploymentID() {
 	deployment := types.Deployment{}
 
-	_, err := suite.environment.AddDeployment(suite.ctx, *suite.environment1, deployment)
+	_, err := suite.environment.AddPendingDeployment(suite.ctx, *suite.environment1, deployment)
 	assert.Error(suite.T(), err, "Expected an error when deployment ID is missing")
 }
 
 func (suite *EnvironmentTestSuite) TestAddDeploymentDeploymentExists() {
 	suite.environment1.Deployments[suite.deployment.ID] = *suite.deployment
 
-	_, err := suite.environment.AddDeployment(suite.ctx, *suite.environment1, *suite.deployment)
+	_, err := suite.environment.AddPendingDeployment(suite.ctx, *suite.environment1, *suite.deployment)
 	assert.Error(suite.T(), err, "Expected an error when deployment exists")
 }
 
@@ -345,7 +345,7 @@ func (suite *EnvironmentTestSuite) TestAddDeploymentPutEnvironmentFails() {
 		verifyEnvironment(suite.T(), suite.environment1, &e)
 	}).Return(errors.New("Put environment failed"))
 
-	_, err := suite.environment.AddDeployment(suite.ctx, *suite.environment1, *suite.deployment)
+	_, err := suite.environment.AddPendingDeployment(suite.ctx, *suite.environment1, *suite.deployment)
 	assert.Error(suite.T(), err, "Expected an error when put environment fails")
 }
 
@@ -354,7 +354,7 @@ func (suite *EnvironmentTestSuite) TestAddDeployment() {
 	updatedEnv.PendingDeploymentID = suite.deployment.ID
 	suite.environmentStore.EXPECT().PutEnvironment(suite.ctx, gomock.Eq(*updatedEnv)).Return(nil)
 
-	env, err := suite.environment.AddDeployment(suite.ctx, *suite.environment1, *suite.deployment)
+	env, err := suite.environment.AddPendingDeployment(suite.ctx, *suite.environment1, *suite.deployment)
 	assert.Nil(suite.T(), err, "Unexpected error when adding a deployment")
 
 	suite.environment1.Deployments[suite.deployment.ID] = *suite.deployment
@@ -414,7 +414,7 @@ func (suite *EnvironmentTestSuite) TestUpdateDeploymentEnvironmentDoesNotHaveCur
 }
 
 func (suite *EnvironmentTestSuite) TestUpdateDeploymentEnvironmentCurrentTasksContainsADifferentTaskDef() {
-	suite.environment1.Deployments[suite.deployment.ID] = *suite.deployment
+	suite.environment1.AddPendingDeployment(*suite.deployment)
 
 	suite.updatedEnvironment.Deployments[suite.deployment.ID] = *suite.updatedDeployment
 

--- a/daemon-scheduler/pkg/engine/monitor.go
+++ b/daemon-scheduler/pkg/engine/monitor.go
@@ -63,7 +63,7 @@ func (m monitor) InProgressMonitorLoop(tickerDuration time.Duration) {
 					}
 				}
 			case <-m.ctx.Done():
-				log.Infof("Shutting down in-progress monitor")
+				log.Info("Shutting down the in-progress monitor")
 				ticker.Stop()
 				return
 			}
@@ -84,7 +84,7 @@ func (m monitor) PendingMonitorLoop(tickerDuration time.Duration) {
 					}
 				}
 			case <-m.ctx.Done():
-				log.Infof("Shutting down pending monitor")
+				log.Info("Shutting down the pending monitor")
 				ticker.Stop()
 				return
 			}

--- a/daemon-scheduler/pkg/facade/css.go
+++ b/daemon-scheduler/pkg/facade/css.go
@@ -45,7 +45,7 @@ func (c clusterState) ListInstances(cluster string) ([]*models.ContainerInstance
 
 	resp, err := c.client.Operations.ListInstances(req)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error calling ListInstances with req %v", req)
+		return nil, errors.Wrapf(err, "Error calling ListInstances with cluster %v", cluster)
 	}
 
 	return resp.Payload.Items, nil
@@ -57,7 +57,7 @@ func (c clusterState) ListTasks(cluster string) ([]*models.Task, error) {
 
 	resp, err := c.client.Operations.ListTasks(req)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error calling ListTasks with req %v", req)
+		return nil, errors.Wrapf(err, "Error calling ListTasks with cluster %v", cluster)
 	}
 	return resp.Payload.Items, nil
 }

--- a/daemon-scheduler/pkg/mocks/environment_mocks.go
+++ b/daemon-scheduler/pkg/mocks/environment_mocks.go
@@ -97,15 +97,15 @@ func (_mr *_MockEnvironmentRecorder) FilterEnvironments(arg0, arg1, arg2 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FilterEnvironments", arg0, arg1, arg2)
 }
 
-func (_m *MockEnvironment) AddDeployment(ctx context.Context, environment types.Environment, deployment types.Deployment) (*types.Environment, error) {
-	ret := _m.ctrl.Call(_m, "AddDeployment", ctx, environment, deployment)
+func (_m *MockEnvironment) AddPendingDeployment(ctx context.Context, environment types.Environment, deployment types.Deployment) (*types.Environment, error) {
+	ret := _m.ctrl.Call(_m, "AddPendingDeployment", ctx, environment, deployment)
 	ret0, _ := ret[0].(*types.Environment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEnvironmentRecorder) AddDeployment(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddDeployment", arg0, arg1, arg2)
+func (_mr *_MockEnvironmentRecorder) AddPendingDeployment(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddPendingDeployment", arg0, arg1, arg2)
 }
 
 func (_m *MockEnvironment) UpdateDeployment(ctx context.Context, environment types.Environment, deployment types.Deployment) (*types.Environment, error) {

--- a/daemon-scheduler/pkg/types/environment.go
+++ b/daemon-scheduler/pkg/types/environment.go
@@ -34,12 +34,12 @@ type Environment struct {
 	DesiredTaskCount      int
 	Cluster               string
 	Health                EnvironmentHealth
+
 	// ID of the deployment created by the latest create-deployment call.
-	// This need not necessarily correspond to the deployment picked up by the
-	// background jobs launching tasks
 	PendingDeploymentID string
-	// The ID of the deployment that is being used by the background workers to
-	// to launch tasks
+	// ID of the deployment that is currently in-progress. Background workers will pick
+	// up this deployment to launch tasks on new instances if there is an in-progress deployment.
+	// Otherwise, if no in-progress deployment exists, background workers pick up the latest completed deployment.
 	InProgressDeploymentID string
 
 	// deploymentID -> deployment
@@ -69,6 +69,53 @@ func NewEnvironment(name string, taskDefinition string, cluster string) (*Enviro
 	}, nil
 }
 
+func (e *Environment) AddPendingDeployment(d Deployment) error {
+	if d.Status != DeploymentPending {
+		return errors.Errorf("Cannot add deployment %v to environment %v as a pending deployment because its status is %v and not pending",
+			d.ID, e.Name, d.Status)
+	}
+
+	e.Deployments[d.ID] = d
+	e.PendingDeploymentID = d.ID
+
+	return nil
+}
+
+func (e *Environment) UpdatePendingDeploymentToInProgress() error {
+	d, err := e.getPendingDeployment()
+	if err != nil {
+		return err
+	}
+
+	if d == nil {
+		return errors.Errorf("There is no pending deployment in the environment %v", e.Name)
+	}
+
+	e.InProgressDeploymentID = d.ID
+	e.PendingDeploymentID = ""
+
+	return nil
+}
+
+func (e *Environment) getPendingDeployment() (*Deployment, error) {
+	if e.PendingDeploymentID == "" {
+		return nil, nil
+	}
+
+	d, ok := e.Deployments[e.PendingDeploymentID]
+	if !ok {
+		return nil, errors.Errorf("Pending deployment %v does not exist in the deployments for the environment %v",
+			e.PendingDeploymentID, e.Name)
+	}
+
+	if d.Status != DeploymentPending {
+		return nil, errors.Errorf("Pending deployment %v in the environment %v is not in a pending status but %v",
+			d.ID, e.Name, d.Status)
+	}
+
+	return &d, nil
+}
+
 type timeOrderedDeployments []Deployment
 
 func (p timeOrderedDeployments) Len() int {
@@ -85,7 +132,7 @@ func (p timeOrderedDeployments) Swap(i, j int) {
 }
 
 // SortDeploymentsReverseChronologically returns deployments ordered reverse-chronologically: latest startTime first
-func (e Environment) SortDeploymentsReverseChronologically() ([]Deployment, error) {
+func (e *Environment) SortDeploymentsReverseChronologically() ([]Deployment, error) {
 	deployments := make([]Deployment, 0, len(e.Deployments))
 	for _, d := range e.Deployments {
 		deployments = append(deployments, d)


### PR DESCRIPTION
… to the environment


#### Summary
<!-- What does this pull request do? -->
Adding environment methods to add pending and in-progress deployments to the environment
https://github.com/blox/blox/issues/118

#### Testing
<!-- How was this tested? -->
- [x] daemon-scheduler binary built locally and unit-tests pass (`cd daemon-scheduler; make; cd ../`)
- [x] daemon-scheduler build in Docker succeeds (`cd daemon-scheduler; make release; cd ../`)

New tests cover the changes:  yes

#### Licensing

This contribution is under the terms of the Apache 2.0 License: Yes

#### Before merging
<!-- Run integration and end-to-end tests before merging -->
- [x] daemon-scheduler integration tests pass. Required setup details are listed [here](https://github.com/blox/blox/blob/dev/daemon-scheduler/internal/features/README.md).
- [x] daemon-scheduler end-to-end tests pass. Required setup details are listed [here](https://github.com/blox/blox/blob/dev/daemon-scheduler/internal/features/README.md).
