### PR TITLE
feat(cluster-state-service): add ping endpoint

### DIFF
--- a/cluster-state-service/handler/api/v1/generalapis.go
+++ b/cluster-state-service/handler/api/v1/generalapis.go
@@ -14,19 +14,23 @@
 package v1
 
 import (
+	"net/http"
+
 	"github.com/blox/blox/cluster-state-service/handler/store"
 )
 
-type APIs struct {
-	GeneralApis           GeneralAPIs
-	TaskApis              TaskAPIs
-	ContainerInstanceApis ContainerInstanceAPIs
+// TaskAPIs encapsulates the backend datastore with which the task APIs interact
+type GeneralAPIs struct {
+	taskStore store.TaskStore
 }
 
-func NewAPIs(stores store.Stores) APIs {
-	return APIs{
-		GeneralApis:           NewGeneralAPIs(),
-		TaskApis:              NewTaskAPIs(stores.TaskStore),
-		ContainerInstanceApis: NewContainerInstanceAPIs(stores.ContainerInstanceStore),
-	}
+// NewTaskAPIs initializes the TaskAPIs struct
+func NewGeneralAPIs() GeneralAPIs {
+	return GeneralAPIs{}
+}
+
+// Ping is used to perform server health checks
+func (api GeneralAPIs) Ping(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set(contentTypeKey, contentTypeJSON)
+	w.WriteHeader(http.StatusOK)
 }

--- a/cluster-state-service/handler/api/v1/generalapis_test.go
+++ b/cluster-state-service/handler/api/v1/generalapis_test.go
@@ -1,0 +1,73 @@
+// Copyright 2016-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package v1
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type GeneralAPIsTestSuite struct {
+	suite.Suite
+	generalAPIs          GeneralAPIs
+	responseHeaderJSON   http.Header
+	responseHeaderStream http.Header
+
+	// We need a router because some of the apis use mux.Vars() which uses the URL
+	// parameters parsed and stored in a global map in the global context by the router.
+	router *mux.Router
+}
+
+func (suite *GeneralAPIsTestSuite) SetupTest() {
+	suite.generalAPIs = NewGeneralAPIs()
+	suite.router = suite.getRouter()
+}
+
+// TODO - Add the following test cases once implementation is in place
+// * arn validation fails on getTask
+// * streaming api
+
+func TestGeneralAPIsTestSuite(t *testing.T) {
+	suite.Run(t, new(GeneralAPIsTestSuite))
+}
+
+func (suite *GeneralAPIsTestSuite) TestPing() {
+	request, err := http.NewRequest("GET", "/v1/ping", nil)
+	assert.Nil(suite.T(), err, "Unexpected error creating ping request")
+
+	responseRecorder := httptest.NewRecorder()
+	suite.router.ServeHTTP(responseRecorder, request)
+
+	header := responseRecorder.Header()
+	assert.NotNil(suite.T(), header, "Unexpected empty header in ping response")
+	expectedHeader := http.Header{"Content-Type": []string{"application/json; charset=UTF-8"}}
+	assert.Equal(suite.T(), expectedHeader, header, "Http header in ping response is  invalid")
+	assert.Equal(suite.T(), http.StatusOK, responseRecorder.Code, "Http response status in ping response is invalid")
+}
+
+func (suite *GeneralAPIsTestSuite) getRouter() *mux.Router {
+	r := mux.NewRouter().StrictSlash(true)
+	s := r.Path("/v1").Subrouter()
+
+	s.Path(getPingPath).
+		Methods("GET").
+		HandlerFunc(suite.generalAPIs.Ping)
+
+	return s
+}

--- a/cluster-state-service/handler/api/v1/router.go
+++ b/cluster-state-service/handler/api/v1/router.go
@@ -20,6 +20,8 @@ import (
 
 // TODO: add a map of path and query keys and use the map in task apis instead of hardcoding strings
 var (
+	getPingPath = "/ping"
+
 	// Stripping off '^' and '$' from the beginning and end of regexes respectively for the router
 	clusterNameRegex = string(regex.ClusterNameRegex[1 : len(regex.ClusterNameRegex)-1])
 	clusterARNRegex  = string(regex.ClusterARNRegex[1 : len(regex.ClusterARNRegex)-1])
@@ -39,6 +41,12 @@ var (
 func NewRouter(apis APIs) *mux.Router {
 	r := mux.NewRouter().StrictSlash(true)
 	s := r.Path("/v1").Subrouter()
+
+	// Health
+
+	s.Path("/ping").
+		Methods("GET").
+		HandlerFunc(apis.GeneralApis.Ping)
 
 	// Tasks
 

--- a/cluster-state-service/swagger/v1/swagger.json
+++ b/cluster-state-service/swagger/v1/swagger.json
@@ -22,6 +22,17 @@
     "application/json"
   ],
   "paths": {
+    "/ping": {
+      "get": {
+        "description": "Ping server for health status",
+        "operationId": "ping",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/instances/{cluster}/{arn}": {
       "get": {
         "description": "Get instance using cluster name and instance ARN",


### PR DESCRIPTION
#### Summary
Adds a "ping" endpoint to `cluster-state-service` at `/v1/ping` which behaves exactly like the same endpoint in `daemon-scheduler`. (fixes #194)

#### Implementation details
I copy-pasta'd a lot over from `daemon-scheduler`.

#### Testing
<!-- How was this tested? -->
- [ ] cluster-state-service binary built locally and unit-tests pass (`cd cluster-state-service; make; cd ../`)
- [ ] cluster-state-service build in Docker succeeds (`cd cluster-state-service; make release; cd ../`)
- [ ] daemon-scheduler binary built locally and unit-tests pass (`cd daemon-scheduler; make; cd ../`)
- [ ] daemon-scheduler build in Docker succeeds (`cd daemon-scheduler; make release; cd ../`)

New tests cover the changes: yes

#### Description for the changelog
added a health check endpoint

#### Licensing

This contribution is under the terms of the Apache 2.0 License: Yes

#### Before merging
<!-- Run integration and end-to-end tests before merging -->
- [ ] cluster-state-service end-to-end tests pass. Required setup details are listed [here](https://github.com/blox/blox/blob/dev/cluster-state-service/internal/Readme.md).
- [ ] daemon-scheduler integration tests pass. Required setup details are listed [here](https://github.com/blox/blox/blob/dev/daemon-scheduler/internal/features/README.md).
- [ ] daemon-scheduler end-to-end tests pass. Required setup details are listed [here](https://github.com/blox/blox/blob/dev/daemon-scheduler/internal/features/README.md).
