### PR TITLE
Clarifying $GOPATH

### DIFF
--- a/daemon-scheduler/README.md
+++ b/daemon-scheduler/README.md
@@ -19,7 +19,7 @@ The daemon-scheduler API:
 
 ### Building the daemon-scheduler
 
-The daemon-scheduler depends on golang and go-swagger. Install and configure [golang](https://golang.org/doc/). For more information about installing go-swagger, see the [go-swagger documentation](https://github.com/go-swagger/go-swagger). Also, make sure to clone this repo into your appropriate [GOPATH](https://golang.org/doc/code.html#Workspaces) directory.
+The daemon-scheduler depends on golang and go-swagger. Install and configure [golang](https://golang.org/doc/). For more information about installing go-swagger, see the [go-swagger documentation](https://github.com/go-swagger/go-swagger). Also, make sure to clone this repo into your appropriate [$GOPATH](https://golang.org/doc/code.html#GOPATH) directory.
 
 ```
 $ git clone https://github.com/blox/blox.git blox/blox

--- a/daemon-scheduler/README.md
+++ b/daemon-scheduler/README.md
@@ -19,7 +19,7 @@ The daemon-scheduler API:
 
 ### Building the daemon-scheduler
 
-The daemon-scheduler depends on golang and go-swagger. Install and configure [golang](https://golang.org/doc/). For more information about installing go-swagger, see the [go-swagger documentation](https://github.com/go-swagger/go-swagger).
+The daemon-scheduler depends on golang and go-swagger. Install and configure [golang](https://golang.org/doc/). For more information about installing go-swagger, see the [go-swagger documentation](https://github.com/go-swagger/go-swagger). Also, make sure to clone this repo into your appropriate [GOPATH](https://golang.org/doc/code.html#Workspaces) directory.
 
 ```
 $ git clone https://github.com/blox/blox.git blox/blox


### PR DESCRIPTION
#### Summary
Helping non-go developers save 30 minutes by indicating where the repo should be cloned.

#### Implementation details
Small sentence added to daemon-scheduler's README

#### Testing
I read the README

New tests cover the changes: <!-- yes|no -->

#### Description for the changelog
Indication of $GOPATH

#### Licensing

This contribution is under the terms of the Apache 2.0 License: Yes

#### Before merging
<!-- Run integration and end-to-end tests before merging -->
- [ ] cluster-state-service end-to-end tests pass. Required setup details are listed [here](https://github.com/blox/blox/blob/dev/cluster-state-service/internal/Readme.md).
- [ ] daemon-scheduler integration tests pass. Required setup details are listed [here](https://github.com/blox/blox/blob/dev/daemon-scheduler/internal/features/README.md).
- [ ] daemon-scheduler end-to-end tests pass. Required setup details are listed [here](https://github.com/blox/blox/blob/dev/daemon-scheduler/internal/features/README.md).
