### PR TITLE
Add basic support for IAM authentication on all frontend calls (#224)

### DIFF
--- a/buildSrc/src/main/java/com/amazonaws/blox/swagger/ApiGatewaySecurityFilter.java
+++ b/buildSrc/src/main/java/com/amazonaws/blox/swagger/ApiGatewaySecurityFilter.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.swagger;
+
+import io.swagger.models.Operation;
+import io.swagger.models.Path;
+import io.swagger.models.Swagger;
+import io.swagger.models.auth.ApiKeyAuthDefinition;
+import io.swagger.models.auth.In;
+import java.util.Collections;
+import lombok.Getter;
+import lombok.Setter;
+import org.gradle.api.tasks.Input;
+
+@Getter
+@Setter
+/**
+ * Apply a Swagger Security Definition to all methods of an API.
+ *
+ * <p>This defaults to applying AWS Signature Version 4 authentication.
+ *
+ * <p>TODO Move everything in com.amazonaws.blox.swagger to a separate project
+ */
+public class ApiGatewaySecurityFilter implements SwaggerFilter {
+  private static final String SECURITY_SCHEME_NAME = "defaultAuthorization";
+
+  /**
+   * The authentication type for the generated swagger model, defaults to AWS Signature Version 4
+   *
+   * <p>See the documentation for more details:
+   * http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-authtype.html
+   */
+  @Input private String authType = "awsSigv4";
+
+  @Override
+  public void apply(Swagger swagger) {
+    ApiKeyAuthDefinition authorization = new ApiKeyAuthDefinition("Authorization", In.HEADER);
+    authorization.setVendorExtension("x-amazon-apigateway-authtype", authType);
+    swagger.securityDefinition(SECURITY_SCHEME_NAME, authorization);
+
+    for (Path path : swagger.getPaths().values()) {
+      for (Operation operation : path.getOperations()) {
+        operation.addSecurity(SECURITY_SCHEME_NAME, Collections.emptyList());
+      }
+    }
+  }
+}

--- a/end-to-end-tests/build.gradle
+++ b/end-to-end-tests/build.gradle
@@ -25,4 +25,5 @@ task testEndToEnd(type: Test) {
 
     dependsOn deployTask
     systemProperty 'blox.tests.stackoutputs', deployTask.outputs.files.singleFile
+    systemProperty 'blox.tests.awsProfile', awsProfile
 }

--- a/end-to-end-tests/src/test/java/com/amazonaws/blox/EnvironmentTest.java
+++ b/end-to-end-tests/src/test/java/com/amazonaws/blox/EnvironmentTest.java
@@ -16,30 +16,34 @@ package com.amazonaws.blox;
 
 import static org.junit.Assert.assertEquals;
 
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.blox.model.DescribeEnvironmentRequest;
 import com.amazonaws.blox.model.DescribeEnvironmentResult;
+import com.amazonaws.opensdk.protect.auth.RequestSignerNotFoundException;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.net.URL;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class EnvironmentTest {
-  private Blox client = Blox.builder().endpoint(endpoint()).build();
+  private static final String stackOutputsFile = System.getProperty("blox.tests.stackoutputs");
+  private static final String awsProfile = System.getProperty("blox.tests.awsProfile");
 
-  @Test
-  public void describeEnvironmentReturnsFakeEnvironment() throws Exception {
-    DescribeEnvironmentResult result =
-        client.describeEnvironment(new DescribeEnvironmentRequest().name("foo"));
-    assertEquals("foo", result.getEnvironment().getName());
-  }
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  private final Blox client =
+      Blox.builder()
+          .endpoint(endpoint())
+          .iamCredentials(new ProfileCredentialsProvider(awsProfile))
+          .build();
 
   private static String endpoint() {
     try {
-      JsonNode tree =
-          new ObjectMapper(new JsonFactory())
-              .readTree(new File(System.getProperty("blox.tests.stackoutputs")));
+      JsonNode tree = new ObjectMapper(new JsonFactory()).readTree(new File(stackOutputsFile));
       String urlString = tree.get("ApiUrl").asText();
 
       // The generated client doesn't like the stage name in the endpoint, so strip it out:
@@ -48,5 +52,21 @@ public class EnvironmentTest {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Test
+  public void describeEnvironmentReturnsFakeEnvironment() throws Exception {
+    DescribeEnvironmentResult result =
+        client.describeEnvironment(new DescribeEnvironmentRequest().name("foo"));
+
+    assertEquals("foo", result.getEnvironment().getName());
+  }
+
+  @Test
+  public void unauthenticatedCallsFail() throws Exception {
+    Blox unauthenticatedClient = Blox.builder().endpoint(endpoint()).build();
+
+    thrown.expect(RequestSignerNotFoundException.class);
+    unauthenticatedClient.describeEnvironment(new DescribeEnvironmentRequest().name("foo"));
   }
 }

--- a/frontend-service-client/README.html
+++ b/frontend-service-client/README.html
@@ -67,6 +67,14 @@ Clients clean up their resources when garbage collected but if you want to expli
 client.shutdown();
 // Client is now unusable
 </code></pre>
+<h2>Authorization</h2>
+<h3>AWS Identity and Access Management (IAM) authentication</h3>
+<p>The service client natively supports AWS_IAM authentication using AWS credentials. To configure the AWS credentials used by the client, use the <code>iamCredentials</code> fluent setter.</p>
+<pre><code class="language-java">Blox client = Blox.builder()
+    .iamCredentials(new ProfileCredentialsProvider(&quot;personal&quot;))
+    .build();
+</code></pre>
+<p>The <code>iamCredentials</code> method takes an instance of <a href="http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/AWSCredentialsProvider.html">AWSCredentialsProvider</a>. There are several implementations of AWSCredentialsProvider available and you can also implement your own.</p>
 <h2>Making requests</h2>
 <p>After a client is configured and created, you can make a request to the service. A method on the client interface (<code>Blox</code>) is created for all actions (resource + method) in your API.</p>
 <p>For each API method, classes are generated that represent the request and response of that API. The request class has setters for any path parameters, query parameters, headers, and payload model that are defined in the API. The response class exposes getters for any modeled headers and for the modeled payload.</p>

--- a/frontend-service-client/README.md
+++ b/frontend-service-client/README.md
@@ -93,6 +93,15 @@ client.shutdown();
 // Client is now unusable
 ```
 
+## Authorization
+### AWS Identity and Access Management (IAM) authentication
+The service client natively supports AWS_IAM authentication using AWS credentials. To configure the AWS credentials used by the client, use the `iamCredentials` fluent setter.
+```java
+Blox client = Blox.builder()
+    .iamCredentials(new ProfileCredentialsProvider("personal"))
+    .build();
+```
+The `iamCredentials` method takes an instance of [AWSCredentialsProvider](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/AWSCredentialsProvider.html). There are several implementations of AWSCredentialsProvider available and you can also implement your own.
 
 ## Making requests
 After a client is configured and created, you can make a request to the service. A method on the client interface (`Blox`) is created for all actions (resource + method) in your API.

--- a/frontend-service-client/src/main/java/com/amazonaws/blox/BloxClientBuilder.java
+++ b/frontend-service-client/src/main/java/com/amazonaws/blox/BloxClientBuilder.java
@@ -7,6 +7,8 @@ import com.amazonaws.annotation.NotThreadSafe;
 import com.amazonaws.client.AwsSyncClientParams;
 import com.amazonaws.opensdk.protect.client.SdkSyncClientBuilder;
 import com.amazonaws.opensdk.internal.config.ApiGatewayClientConfigurationFactory;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.Signer;
 import com.amazonaws.util.RuntimeHttpUtils;
 import com.amazonaws.Protocol;
 
@@ -33,6 +35,53 @@ public final class BloxClientBuilder extends SdkSyncClientBuilder<BloxClientBuil
     }
 
     /**
+     * Specify an implementation of {@link AWSCredentialsProvider} to be used when signing IAM auth'd requests
+     *
+     * @param iamCredentials
+     *        the credential provider
+     */
+    @Override
+    public void setIamCredentials(AWSCredentialsProvider iamCredentials) {
+        super.setIamCredentials(iamCredentials);
+    }
+
+    /**
+     * Specify an implementation of {@link AWSCredentialsProvider} to be used when signing IAM auth'd requests
+     *
+     * @param iamCredentials
+     *        the credential provider
+     * @return This object for method chaining.
+     */
+    public BloxClientBuilder iamCredentials(AWSCredentialsProvider iamCredentials) {
+        setIamCredentials(iamCredentials);
+        return this;
+    }
+
+    /**
+     * Sets the IAM region to use when using IAM auth'd requests against a service in any of it's non-default regions.
+     * This is only expected to be used when a custom endpoint has also been set.
+     *
+     * @param iamRegion
+     *        the IAM region string to use when signing
+     */
+    public void setIamRegion(String iamRegion) {
+        super.setIamRegion(iamRegion);
+    }
+
+    /**
+     * Sets the IAM region to use when using IAM auth'd requests against a service in any of it's non-default regions.
+     * This is only expected to be used when a custom endpoint has also been set.
+     *
+     * @param iamRegion
+     *        the IAM region string to use when signing
+     * @return This object for method chaining.
+     */
+    public BloxClientBuilder iamRegion(String iamRegion) {
+        setIamRegion(iamRegion);
+        return this;
+    }
+
+    /**
      * Construct a synchronous implementation of Blox using the current builder configuration.
      *
      * @param params
@@ -54,4 +103,8 @@ public final class BloxClientBuilder extends SdkSyncClientBuilder<BloxClientBuil
         return DEFAULT_REGION;
     }
 
+    @Override
+    protected Signer defaultIamSigner() {
+        return signerFactory().createSigner();
+    }
 }

--- a/frontend-service-client/src/main/java/com/amazonaws/blox/model/DescribeEnvironmentRequest.java
+++ b/frontend-service-client/src/main/java/com/amazonaws/blox/model/DescribeEnvironmentRequest.java
@@ -6,13 +6,16 @@ package com.amazonaws.blox.model;
 import java.io.Serializable;
 import javax.annotation.Generated;
 
+import com.amazonaws.auth.RequestSigner;
+import com.amazonaws.opensdk.protect.auth.RequestSignerAware;
+
 /**
  * 
  * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/joufu8ief9-v2017-07-11/DescribeEnvironment" target="_top">AWS
  *      API Documentation</a>
  */
 @Generated("com.amazonaws:aws-java-sdk-code-generator")
-public class DescribeEnvironmentRequest extends com.amazonaws.opensdk.BaseRequest implements Serializable, Cloneable {
+public class DescribeEnvironmentRequest extends com.amazonaws.opensdk.BaseRequest implements Serializable, Cloneable, RequestSignerAware {
 
     private String name;
 
@@ -88,6 +91,11 @@ public class DescribeEnvironmentRequest extends com.amazonaws.opensdk.BaseReques
     @Override
     public DescribeEnvironmentRequest clone() {
         return (DescribeEnvironmentRequest) super.clone();
+    }
+
+    @Override
+    public Class<? extends RequestSigner> signerType() {
+        return com.amazonaws.opensdk.protect.auth.IamRequestSigner.class;
     }
 
     /**

--- a/frontend-service/api/swagger.yml
+++ b/frontend-service/api/swagger.yml
@@ -24,16 +24,24 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/Environment"
+      security:
+      - defaultAuthorization: []
       x-amazon-apigateway-integration:
         passthroughBehavior: "when_no_match"
         httpMethod: "POST"
         type: "aws_proxy"
         uri:
           Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${FrontendHandler.Arn}/invocations"
+securityDefinitions:
+  defaultAuthorization:
+    type: "apiKey"
+    name: "Authorization"
+    in: "header"
+    x-amazon-apigateway-authtype: "awsSigv4"
 definitions:
   Environment:
     type: "object"
     properties:
       name:
         type: "string"
-x-generated-at: "2017-08-03T18:27:27.203Z"
+x-generated-at: "2017-08-09T21:11:30.642Z"

--- a/frontend-service/build.gradle
+++ b/frontend-service/build.gradle
@@ -1,3 +1,4 @@
+import com.amazonaws.blox.swagger.ApiGatewaySecurityFilter
 import com.amazonaws.blox.tasks.GenerateSwaggerModel
 import io.swagger.models.Info
 
@@ -58,6 +59,7 @@ task swagger(type: GenerateSwaggerModel, dependsOn: classes) {
     } as SwaggerFilter)
 
     filters.add(new ApiGatewayExtensionsFilter("arn:aws:apigateway:\${AWS::Region}:lambda:path/2015-03-31/functions/\${FrontendHandler.Arn}/invocations"))
+    filters.add(new ApiGatewaySecurityFilter())
 }
 
 task packageLambda(type: Zip, dependsOn: classes) {


### PR DESCRIPTION
#### Summary
This adds another Swagger filter that inserts the necessary API Gateway
swagger extensions to enable IAM Authentication. See #224 for details.

#### Testing
```
gradle check
gradle testEndToEnd
```

#### Licensing

This contribution is under the terms of the Apache 2.0 License: Yes