### PR TITLE
Figure out how to namespace test stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,41 @@ To run the full unit test suite, run:
 This will run the same tests that we run in the Travis CI build.
 
 ### Deploying
-To deploy a personal stack:
+First, take a look at what Blox will put in your personal stack by running the
+`showStackConfig` task:
+
+```
+$ ./gradlew showStackConfig
+
+> Task :showStackConfig
+Blox deployment stack configuration:
+
+  Default resource name         (blox.name): blox-buys-alpha-us-west-2 (default)
+  API Gateway stage            (blox.stage): alpha (default)
+  Stack prefix                (blox.prefix): buys-alpha (default)
+  AWS Region                  (blox.region): us-west-2 (default)
+  AWS Credential Profile     (blox.profile): blox-buys-alpha-us-west-2 (default)
+  Cloudformation stack name (blox.cfnStack): blox-buys-alpha-us-west-2 (default)
+  Deployment S3 bucket name (blox.s3Bucket): blox-buys-alpha-us-west-2 (default)
+
+To customize these values, modify ~/.gradle/gradle.properties to override the property listed.
+
+AWS CLI configuration for profile blox-buys-alpha-us-west-2:
+
+The config profile (blox-buys-alpha-us-west-2) could not be found
+```
+
+If you wish to customize any of these values, you can do so by overriding the
+property in parentheses using [any of the supported ways to override Gradle
+properties](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_properties_and_system_properties).
+The easiest way is to override it for your user in `~/.gradle/gradle.properties`:
+
+```
+blox.profile=default
+blox.region=us-east-1
+```
+
+Next, in order to deploy your personal stack:
 - install the [official AWS CLI](https://aws.amazon.com/cli/)
 - create an IAM user with the following permissions:
 
@@ -49,7 +83,14 @@ To deploy a personal stack:
     ```
 
   These permissions are pretty broad, so we recommend you use a separate, test account.
-- configure the `default` profile with the AWS credentials for the user you created above
+
+- configure the AWS Credential Profile shown in the `showStackOutput` task with
+  the AWS credentials for the user you created above:
+  
+    ```
+    aws configure --profile buys-blox-alpha-us-west-2
+    ```
+
 - create an S3 bucket where all resources (code, cloudformation templates, etc) to be deployed will be stored:
 
     ```
@@ -68,6 +109,7 @@ Once you have a stack deployed, you can test it with:
 ```
 ./gradlew testEndToEnd
 ```
+
 
 ### Contact
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,6 @@
 import groovy.json.JsonSlurper
+import groovy.transform.Canonical
+import groovy.transform.Memoized
 
 group 'com.amazonaws.blox'
 version '0.1-SNAPSHOT'
@@ -40,25 +42,86 @@ wrapper {
     distributionType = 'all'
 }
 
+class BloxStack {
+    @Canonical
+    class BloxProperty {
+        String name
+        String getPropertyName() { "blox.${name}" }
+        String description
+        Closure<String> defaultValue
+
+        String toString() {
+            isOverridden() ? BloxStack.this.project[propertyName] : defaultValue()
+        }
+
+        boolean isOverridden() {
+            BloxStack.this.project.hasProperty(propertyName)
+        }
+
+        String toDescription() {
+            "${description.padRight(25)} ${"(${propertyName})".padLeft(15)}: ${this} ${isOverridden() ? "" : "(default)"}"
+        }
+    }
+
+    Project project
+    String currentUser = System.getenv("USER")
+
+    BloxStack(Project project) {
+        this.project = project
+    }
+
+    def name = new BloxProperty("name", "Default resource name", { "blox-${prefix}-${region}"})
+
+    // TODO Changing the stage name requires regenerating the client, since the stage name is
+    //      hard-coded there. We should contribute the ability to configure this to the
+    //      SDK codegen project.
+    def stage = new BloxProperty("stage", "API Gateway stage", { "alpha" })
+    def prefix = new BloxProperty("prefix", "Stack prefix", { "${currentUser}-${stage}" })
+    def region = new BloxProperty("region", "AWS Region", { "us-west-2" })
+
+    def profile = new BloxProperty("profile", "AWS Credential Profile", { name })
+
+    def cfnStack = new BloxProperty("cfnStack", "Cloudformation stack name", { name })
+    def s3Bucket = new BloxProperty("s3Bucket", "Deployment S3 bucket name", { name })
+
+    String toPrettyString(int indent) {
+        def props = [name, stage, prefix, region, profile, cfnStack, s3Bucket]
+        return props.collect { "${' ' * indent}${it.toDescription()}" }.join("\n")
+    }
+}
+
+
 ext {
-    // This can be overridden by specifying -PawsProfile=my-other-profile
-    // on the Gradle command line:
-    awsProfile = project.hasProperty("awsProfile") ? project.awsProfile : "default"
-    println("Profile: ${awsProfile}")
+    stack = new BloxStack(project)
 
-    awsCli = "/usr/local/bin/aws"
-    awsRegion = "us-west-2"
-    awsPrefix = System.getenv("USER")
-
-    stackName = "${awsPrefix}-blox-frontend-${awsRegion}"
-    s3BucketName = "${stackName}-${awsProfile}"
-    stageName = "Beta"
+    awsCommand = "aws"
 
     sdkZip = file("${buildDir}/java-sdk-${version}.zip")
 }
 
+task showStackConfig() {
+    group "help"
+    description "Display the names of AWS resources used for deployment"
+
+    doLast {
+        println "Blox deployment stack configuration:"
+        println()
+        println(stack.toPrettyString(2))
+
+        println()
+        println "To customize these values, modify ~/.gradle/gradle.properties to override the property listed."
+
+        println()
+        println "AWS CLI configuration for profile ${stack.profile}:"
+        exec {
+            commandLine aws("configure", "list")
+        }
+
+    }
+}
+
 def aws(... args) {
-    return [awsCli, "--profile", awsProfile, "--region", awsRegion, *args]
+    return [awsCommand, "--profile", stack.profile, "--region", stack.region, *args]
 }
 
 task downloadClient() {
@@ -87,7 +150,7 @@ task downloadClient() {
         exec {
             commandLine aws("apigateway", "get-sdk",
                     "--rest-api-id", stackOutputs.ApiId,
-                    "--stage-name", stageName,
+                    "--stage-name", stack.stage,
                     "--sdk-type", "java",
                     "--parameters", parameters,
                     sdkZip)

--- a/end-to-end-tests/build.gradle
+++ b/end-to-end-tests/build.gradle
@@ -24,6 +24,6 @@ task testEndToEnd(type: Test) {
     def deployTask = tasks.getByPath(":frontend-infrastructure:deploy")
 
     dependsOn deployTask
-    systemProperty 'blox.tests.awsProfile', awsProfile
+    systemProperty 'blox.tests.awsProfile', stack.profile.toString()
     systemProperty 'blox.tests.apiUrl', deployTask.project.stackOutputs.apiUrl
 }

--- a/end-to-end-tests/build.gradle
+++ b/end-to-end-tests/build.gradle
@@ -24,6 +24,6 @@ task testEndToEnd(type: Test) {
     def deployTask = tasks.getByPath(":frontend-infrastructure:deploy")
 
     dependsOn deployTask
-    systemProperty 'blox.tests.stackoutputs', deployTask.outputs.files.singleFile
     systemProperty 'blox.tests.awsProfile', awsProfile
+    systemProperty 'blox.tests.apiUrl', deployTask.project.stackOutputs.apiUrl
 }

--- a/end-to-end-tests/src/test/java/com/amazonaws/blox/EnvironmentTest.java
+++ b/end-to-end-tests/src/test/java/com/amazonaws/blox/EnvironmentTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 public class EnvironmentTest {
-  private static final String stackOutputsFile = System.getProperty("blox.tests.stackoutputs");
+  private static final String apiUrl = System.getProperty("blox.tests.apiUrl");
   private static final String awsProfile = System.getProperty("blox.tests.awsProfile");
 
   @Rule public final ExpectedException thrown = ExpectedException.none();
@@ -43,11 +43,8 @@ public class EnvironmentTest {
 
   private static String endpoint() {
     try {
-      JsonNode tree = new ObjectMapper(new JsonFactory()).readTree(new File(stackOutputsFile));
-      String urlString = tree.get("ApiUrl").asText();
-
       // The generated client doesn't like the stage name in the endpoint, so strip it out:
-      URL url = new URL(urlString);
+      URL url = new URL(apiUrl);
       return new URL(url.getProtocol(), url.getHost(), url.getPort(), "/").toString();
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/frontend-infrastructure/build.gradle
+++ b/frontend-infrastructure/build.gradle
@@ -14,12 +14,54 @@ buildscript {
     }
 }
 
+class StackOutputs {
+    File file
+    def outputs = null
+
+    StackOutputs(File file) {
+        this.file = file
+    }
+
+    String getApiUrl() {
+        getOutputs()?.ApiUrl
+    }
+
+    String getApiId() {
+        getOutputs()?.ApiId
+    }
+
+    def getOutputs() {
+        if (outputs == null) { read() }
+
+        return outputs
+    }
+
+    def setOutputs(value) {
+        outputs = value
+        write()
+    }
+
+    private void read() {
+        if (file.exists()) {
+            outputs = new JsonSlurper().parse(file)
+        }
+    }
+
+    private void write() {
+        file.write(JsonOutput.toJson(outputs))
+    }
+
+    void delete() {
+        if (file.exists()) { file.delete() }
+    }
+}
+
 ext {
     templateFile = file("cloudformation/template.yml")
     processedTemplateFile = file("${buildDir}/template.json")
     outputTemplateFile = file("${buildDir}/template.output.json")
 
-    stackOutputsFile = file("${buildDir}/${stackName}-${awsProfile}.outputs.json")
+    stackOutputs = new StackOutputs(file("${buildDir}/${stackName}-${awsProfile}.outputs.json"))
 }
 
 def outputOf(taskPath) {
@@ -66,10 +108,9 @@ task deploy(dependsOn: packageCloudformationResources) {
     description "Deploy the Cloudformation package defined by an output template file"
 
     inputs.files tasks.getByPath(":frontend-service:packageLambda"), packageCloudformationResources
-    outputs.file stackOutputsFile
+    outputs.file stackOutputs.file
 
     doLast {
-
         def error = new ByteArrayOutputStream()
         def result = exec {
             commandLine aws("cloudformation", "deploy",
@@ -103,11 +144,18 @@ task deploy(dependsOn: packageCloudformationResources) {
             standardOutput output
         }
 
-        def stackOutputs = new JsonSlurper()
+        stackOutputs.outputs = new JsonSlurper()
                 .parseText(output.toString())
                 .collectEntries { [(it.Key): (it.Value)] }
+    }
+}
 
-        stackOutputsFile.write(JsonOutput.toJson(stackOutputs))
+task showDeployedApi() {
+    group "help"
+    description "Show details about the currently deployed stack"
+
+    doLast {
+        println "API URL: ${stackOutputs.apiUrl ?: "Not Deployed"}"
     }
 }
 
@@ -118,7 +166,7 @@ task deleteStack(type: Exec) {
     commandLine aws("cloudformation", "delete-stack", "--stack-name", stackName)
 
     doLast {
-        stackOutputsFile.delete()
+        stackOutputs.delete()
     }
 }
 

--- a/frontend-infrastructure/build.gradle
+++ b/frontend-infrastructure/build.gradle
@@ -18,17 +18,11 @@ class StackOutputs {
     File file
     def outputs = null
 
-    StackOutputs(File file) {
-        this.file = file
-    }
+    StackOutputs(File file) { this.file = file }
 
-    String getApiUrl() {
-        getOutputs()?.ApiUrl
-    }
+    String getApiUrl() { getOutputs()?.ApiUrl }
 
-    String getApiId() {
-        getOutputs()?.ApiId
-    }
+    String getApiId() { getOutputs()?.ApiId }
 
     def getOutputs() {
         if (outputs == null) { read() }
@@ -61,7 +55,7 @@ ext {
     processedTemplateFile = file("${buildDir}/template.json")
     outputTemplateFile = file("${buildDir}/template.output.json")
 
-    stackOutputs = new StackOutputs(file("${buildDir}/${stackName}-${awsProfile}.outputs.json"))
+    stackOutputs = new StackOutputs(file("${buildDir}/${stack.name}.outputs.json"))
 }
 
 def outputOf(taskPath) {
@@ -72,7 +66,7 @@ task createBucket(type: Exec) {
     group "deployment"
     description "Create the S3 bucket used to store Cloudformation/Lambda resources for deployment"
 
-    commandLine aws("s3", "mb", "s3://${s3BucketName}")
+    commandLine aws("s3", "mb", "s3://${stack.s3Bucket}")
 }
 
 task postprocessCloudformationTemplate(type: PostProcessCloudformation, dependsOn: [":frontend-service:swagger", ":frontend-service:packageLambda"]) {
@@ -99,7 +93,7 @@ task packageCloudformationResources(type: Exec) {
     commandLine aws("cloudformation", "package",
             "--template-file", processedTemplateFile,
             "--output-template-file", outputTemplateFile,
-            "--s3-bucket", s3BucketName)
+            "--s3-bucket", stack.s3Bucket)
 }
 
 
@@ -115,8 +109,8 @@ task deploy(dependsOn: packageCloudformationResources) {
         def result = exec {
             commandLine aws("cloudformation", "deploy",
                     "--template-file", outputTemplateFile,
-                    "--stack-name", stackName,
-                    "--parameter-overrides", "StageName=${stageName}",
+                    "--stack-name", stack.cfnStack,
+                    "--parameter-overrides", "StageName=${stack.stage}",
                     "--capabilities", "CAPABILITY_IAM")
 
             errorOutput error
@@ -138,7 +132,7 @@ task deploy(dependsOn: packageCloudformationResources) {
         def output = new ByteArrayOutputStream()
         exec {
             commandLine aws("cloudformation", "describe-stacks",
-                    "--stack-name", stackName,
+                    "--stack-name", stack.cfnStack,
                     "--query", "Stacks[0].Outputs[*].{Key:OutputKey,Value:OutputValue}",
                     "--output", "json")
             standardOutput output
@@ -163,7 +157,7 @@ task deleteStack(type: Exec) {
     group "debug"
     description "Delete the entire cloudformation stack for the frontend"
 
-    commandLine aws("cloudformation", "delete-stack", "--stack-name", stackName)
+    commandLine aws("cloudformation", "delete-stack", "--stack-name", stack.cfnStack)
 
     doLast {
         stackOutputs.delete()
@@ -175,7 +169,7 @@ task describeStackEvents(type: Exec) {
     description "Show a table of the events for the cloudformation stack for debugging"
 
     commandLine aws("cloudformation", "describe-stack-events",
-            "--stack-name", stackName,
+            "--stack-name", stack.cfnStack,
             "--query", "StackEvents[*].{Time:Timestamp,Type:ResourceType,Status:ResourceStatus,Reason:ResourceStatusReason}",
             "--output", "table")
 }

--- a/frontend-service-client/src/main/java/com/amazonaws/blox/model/transform/DescribeEnvironmentRequestProtocolMarshaller.java
+++ b/frontend-service-client/src/main/java/com/amazonaws/blox/model/transform/DescribeEnvironmentRequestProtocolMarshaller.java
@@ -22,7 +22,7 @@ import com.amazonaws.annotation.SdkInternalApi;
 @SdkInternalApi
 public class DescribeEnvironmentRequestProtocolMarshaller implements Marshaller<Request<DescribeEnvironmentRequest>, DescribeEnvironmentRequest> {
 
-    private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder().protocol(Protocol.API_GATEWAY).requestUri("/Beta/environments/{name}")
+    private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder().protocol(Protocol.API_GATEWAY).requestUri("/alpha/environments/{name}")
             .httpMethodName(HttpMethodName.GET).hasExplicitPayloadMember(false).hasPayloadMembers(false).serviceName("Blox").build();
 
     private final com.amazonaws.opensdk.protect.protocol.ApiGatewayProtocolFactoryImpl protocolFactory;


### PR DESCRIPTION
There was some discussion on #218 about how we namespace our test stacks, and how that integrates with the build logic that acts on AWS resources.

At the moment, it uses the name of the AWS CLI credentials profile to determine the stack name.

What we need from test stacks are:

1. It should be possible to have multiple, independent test stacks within a single account (e.g. I'm working on one feature, and want to test another unrelated feature pending PR, or two developers want to test independent code changes in stacks in the same whitelisted internal account)
2. It should be possible to have separate test stacks in separate accounts, and have developers switch between these by using a Gradle configuration property (e.g. when testing internal vs external stacks)
3. It should be trivial to clean up a test stack completely.

There's 3 main resources for each stack:
- Cloudformation Stack
- S3 Bucket for deployment
- Local files that store stack properties

Of these, S3 bucket names have to be globally unique, and so should be namespaced by stack.

Finally, we need to tie a set of AWS credentials to each stack. The easiest way to do that is through a credential profile.