### PR TITLE
Add core Scheduling lambda functions that can place a single task

### DIFF
--- a/data-service-client/src/main/java/com/amazonaws/blox/dataserviceclient/v1/client/DataServiceLambdaClient.java
+++ b/data-service-client/src/main/java/com/amazonaws/blox/dataserviceclient/v1/client/DataServiceLambdaClient.java
@@ -15,10 +15,16 @@
 package com.amazonaws.blox.dataserviceclient.v1.client;
 
 import com.amazonaws.blox.dataservicemodel.v1.client.DataService;
-import com.amazonaws.blox.dataservicemodel.v1.model.CreateEnvironmentRequest;
-import com.amazonaws.blox.dataservicemodel.v1.model.CreateEnvironmentResponse;
-import com.amazonaws.blox.dataservicemodel.v1.model.StartDeploymentRequest;
-import com.amazonaws.blox.dataservicemodel.v1.model.StartDeploymentResponse;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.CreateEnvironmentRequest;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.CreateEnvironmentResponse;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.DescribeTargetEnvironmentRevisionRequest;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.DescribeTargetEnvironmentRevisionResponse;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListClustersRequest;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListClustersResponse;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListEnvironmentsRequest;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListEnvironmentsResponse;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.StartDeploymentRequest;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.StartDeploymentResponse;
 import lombok.AllArgsConstructor;
 
 /**
@@ -35,6 +41,22 @@ public class DataServiceLambdaClient implements DataService {
 
   @Override
   public StartDeploymentResponse startDeployment(final StartDeploymentRequest request) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ListEnvironmentsResponse listEnvironments(ListEnvironmentsRequest request) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ListClustersResponse listClusters(ListClustersRequest request) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public DescribeTargetEnvironmentRevisionResponse describeTargetEnvironmentRevision(
+      DescribeTargetEnvironmentRevisionRequest request) {
     throw new UnsupportedOperationException();
   }
 }

--- a/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/client/DataService.java
+++ b/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/client/DataService.java
@@ -20,10 +20,16 @@ import com.amazonaws.blox.dataservicemodel.v1.exception.EnvironmentVersionNotFou
 import com.amazonaws.blox.dataservicemodel.v1.exception.EnvironmentVersionOutdatedException;
 import com.amazonaws.blox.dataservicemodel.v1.exception.InvalidParameterException;
 import com.amazonaws.blox.dataservicemodel.v1.exception.ServiceException;
-import com.amazonaws.blox.dataservicemodel.v1.model.CreateEnvironmentRequest;
-import com.amazonaws.blox.dataservicemodel.v1.model.CreateEnvironmentResponse;
-import com.amazonaws.blox.dataservicemodel.v1.model.StartDeploymentRequest;
-import com.amazonaws.blox.dataservicemodel.v1.model.StartDeploymentResponse;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.CreateEnvironmentRequest;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.CreateEnvironmentResponse;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.DescribeTargetEnvironmentRevisionResponse;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.DescribeTargetEnvironmentRevisionRequest;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListClustersRequest;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListClustersResponse;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListEnvironmentsRequest;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListEnvironmentsResponse;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.StartDeploymentRequest;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.StartDeploymentResponse;
 
 public interface DataService {
 
@@ -35,4 +41,16 @@ public interface DataService {
   StartDeploymentResponse startDeployment(StartDeploymentRequest request)
       throws EnvironmentNotFoundException, EnvironmentVersionNotFoundException,
           EnvironmentVersionOutdatedException, InvalidParameterException, ServiceException;
+
+  /** Lists all environments that target a given cluster */
+  ListEnvironmentsResponse listEnvironments(ListEnvironmentsRequest request);
+
+  /** Lists all clusters managed by blox */
+  ListClustersResponse listClusters(ListClustersRequest request);
+
+  /**
+   * Describes the revision of the given EnvironmentVersion that is the current deployment Target.
+   */
+  DescribeTargetEnvironmentRevisionResponse describeTargetEnvironmentRevision(
+      DescribeTargetEnvironmentRevisionRequest request);
 }

--- a/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/DeploymentConfiguration.java
+++ b/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/DeploymentConfiguration.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.dataservicemodel.v1.model;
+
+import java.util.Map;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class DeploymentConfiguration {
+  private final int minimumHealthyPercent;
+
+  // TODO: This is just to support arbitrary deployment configuration properties
+  //       We could alternatively use polymorphic types.
+  private final Map<String, String> constraints;
+}

--- a/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/DeploymentType.java
+++ b/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/DeploymentType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.dataservicemodel.v1.model;
+
+public enum DeploymentType {
+  // TODO Temporary deployment type for steel thread, remove once Daemon is implemented:
+  SingleTask,
+  Daemon
+}

--- a/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/EnvironmentVersion.java
+++ b/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/EnvironmentVersion.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.dataservicemodel.v1.model;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class EnvironmentVersion {
+  private final String environmentId;
+  private final String environmentVersion;
+  private final String taskDefinition;
+  private final DeploymentType deploymentType;
+  private final DeploymentConfiguration deploymentConfiguration;
+}

--- a/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/wrappers/CreateEnvironmentRequest.java
+++ b/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/wrappers/CreateEnvironmentRequest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.dataservicemodel.v1.model.wrappers;
+
+import com.amazonaws.blox.dataservicemodel.v1.model.InstanceGroup;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+@Value
+@Builder
+public class CreateEnvironmentRequest {
+
+  @NonNull private String name;
+
+  @NonNull private String taskDefinition;
+
+  @NonNull private String roleArn;
+
+  @NonNull private InstanceGroup instanceGroup;
+}

--- a/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/wrappers/CreateEnvironmentResponse.java
+++ b/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/wrappers/CreateEnvironmentResponse.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.dataservicemodel.v1.model.wrappers;
+
+import com.amazonaws.blox.dataservicemodel.v1.model.InstanceGroup;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+@Value
+@Builder
+public class CreateEnvironmentResponse {
+
+  @NonNull private String environmentVersion;
+
+  @NonNull private String id;
+
+  @NonNull private String name;
+
+  @NonNull private String taskDefinition;
+
+  @NonNull private String roleArn;
+
+  @NonNull private InstanceGroup instanceGroup;
+}

--- a/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/wrappers/DescribeTargetEnvironmentRevisionRequest.java
+++ b/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/wrappers/DescribeTargetEnvironmentRevisionRequest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.dataservicemodel.v1.model.wrappers;
+
+import lombok.Value;
+
+@Value
+public class DescribeTargetEnvironmentRevisionRequest {
+
+  private final String environmentId;
+}

--- a/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/wrappers/DescribeTargetEnvironmentRevisionResponse.java
+++ b/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/wrappers/DescribeTargetEnvironmentRevisionResponse.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.dataservicemodel.v1.model.wrappers;
+
+import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentVersion;
+import lombok.Value;
+
+@Value
+public class DescribeTargetEnvironmentRevisionResponse {
+  private final EnvironmentVersion environmentVersion;
+}

--- a/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/wrappers/ListClustersRequest.java
+++ b/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/wrappers/ListClustersRequest.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.dataservicemodel.v1.model.wrappers;
+
+public class ListClustersRequest {}

--- a/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/wrappers/ListClustersResponse.java
+++ b/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/wrappers/ListClustersResponse.java
@@ -12,19 +12,12 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-package com.amazonaws.blox.dataservicemodel.v1.model;
+package com.amazonaws.blox.dataservicemodel.v1.model.wrappers;
 
-import lombok.Builder;
-import lombok.NonNull;
+import java.util.List;
 import lombok.Value;
 
 @Value
-@Builder
-public class StartDeploymentResponse {
-
-  @NonNull private final String deploymentId;
-
-  @NonNull private final String environmentName;
-
-  @NonNull private final String environmentVersion;
+public class ListClustersResponse {
+  private final List<String> clusterArns;
 }

--- a/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/wrappers/ListEnvironmentsRequest.java
+++ b/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/wrappers/ListEnvironmentsRequest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.dataservicemodel.v1.model.wrappers;
+
+import lombok.Value;
+
+@Value
+public class ListEnvironmentsRequest {
+  private final String clusterArn;
+}

--- a/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/wrappers/ListEnvironmentsResponse.java
+++ b/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/wrappers/ListEnvironmentsResponse.java
@@ -12,25 +12,12 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-package com.amazonaws.blox.dataservicemodel.v1.model;
+package com.amazonaws.blox.dataservicemodel.v1.model.wrappers;
 
-import lombok.Builder;
-import lombok.NonNull;
+import java.util.List;
 import lombok.Value;
 
 @Value
-@Builder
-public class CreateEnvironmentResponse {
-
-  @NonNull private String environmentVersion;
-
-  @NonNull private String id;
-
-  @NonNull private String name;
-
-  @NonNull private String taskDefinition;
-
-  @NonNull private String roleArn;
-
-  @NonNull private InstanceGroup instanceGroup;
+public class ListEnvironmentsResponse {
+  private final List<String> environmentIds;
 }

--- a/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/wrappers/StartDeploymentRequest.java
+++ b/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/wrappers/StartDeploymentRequest.java
@@ -12,7 +12,7 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-package com.amazonaws.blox.dataservicemodel.v1.model;
+package com.amazonaws.blox.dataservicemodel.v1.model.wrappers;
 
 import lombok.Builder;
 import lombok.NonNull;

--- a/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/wrappers/StartDeploymentResponse.java
+++ b/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/wrappers/StartDeploymentResponse.java
@@ -12,7 +12,7 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-package com.amazonaws.blox.dataservicemodel.v1.model;
+package com.amazonaws.blox.dataservicemodel.v1.model.wrappers;
 
 import lombok.Builder;
 import lombok.NonNull;
@@ -20,13 +20,11 @@ import lombok.Value;
 
 @Value
 @Builder
-public class CreateEnvironmentRequest {
+public class StartDeploymentResponse {
 
-  @NonNull private String name;
+  @NonNull private final String deploymentId;
 
-  @NonNull private String taskDefinition;
+  @NonNull private final String environmentName;
 
-  @NonNull private String roleArn;
-
-  @NonNull private InstanceGroup instanceGroup;
+  @NonNull private final String environmentVersion;
 }

--- a/scheduling-manager/build.gradle
+++ b/scheduling-manager/build.gradle
@@ -12,6 +12,7 @@ repositories {
 dependencyManagement {
     imports {
         mavenBom 'com.amazonaws:aws-java-sdk-bom:1.11.180'
+        mavenBom 'software.amazon.awssdk:bom:2.0.0-preview-4'
     }
     dependencies {
         dependencySet(group: 'org.springframework', version: '4.3.10.RELEASE') {
@@ -24,11 +25,12 @@ dependencyManagement {
 }
 
 dependencies {
-    compile (
+    compile(
             'com.amazonaws:aws-lambda-java-core:1.1.0',
             'com.amazonaws:aws-lambda-java-events:1.3.0',
             'com.amazonaws:aws-lambda-java-log4j2:1.0.0',
 
+            'software.amazon.awssdk:ecs',
             'org.projectlombok:lombok:1.16.18',
 
             'org.apache.logging.log4j:log4j-slf4j-impl:2.8.+',
@@ -38,8 +40,12 @@ dependencies {
             'org.springframework:spring-beans',
             'org.springframework:spring-context',
 
+            'com.spotify:completable-futures:+',
+            project(":data-service-model"),
     )
 
+    testCompile "org.mockito:mockito-core:2.+"
+    testCompile "org.hamcrest:hamcrest-junit:2.+"
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/scheduling-manager/build.gradle
+++ b/scheduling-manager/build.gradle
@@ -48,10 +48,12 @@ dependencies {
             project(":data-service-model"),
     )
 
-    testCompile 'org.springframework:spring-test'
-    testCompile "org.mockito:mockito-core:2.+"
-    testCompile "org.hamcrest:hamcrest-junit:2.+"
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile(
+            'org.springframework:spring-test',
+            'org.mockito:mockito-core:2.+',
+            'org.hamcrest:hamcrest-junit:2.+',
+            'junit:junit:4.12'
+    )
 }
 
 task buildZip(type: Zip) {

--- a/scheduling-manager/build.gradle
+++ b/scheduling-manager/build.gradle
@@ -31,6 +31,10 @@ dependencies {
             'com.amazonaws:aws-lambda-java-log4j2:1.0.0',
 
             'software.amazon.awssdk:ecs',
+            'software.amazon.awssdk:lambda',
+
+            'org.apache.commons:commons-lang3:3.6+',
+
             'org.projectlombok:lombok:1.16.18',
 
             'org.apache.logging.log4j:log4j-slf4j-impl:2.8.+',
@@ -44,6 +48,7 @@ dependencies {
             project(":data-service-model"),
     )
 
+    testCompile 'org.springframework:spring-test'
     testCompile "org.mockito:mockito-core:2.+"
     testCompile "org.hamcrest:hamcrest-junit:2.+"
     testCompile group: 'junit', name: 'junit', version: '4.12'

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/lambda/AwsSdkV2LambdaFunction.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/lambda/AwsSdkV2LambdaFunction.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.lambda;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import lombok.SneakyThrows;
+import lombok.extern.log4j.Log4j2;
+import software.amazon.awssdk.services.lambda.LambdaAsyncClient;
+import software.amazon.awssdk.services.lambda.model.InvocationType;
+import software.amazon.awssdk.services.lambda.model.InvokeRequest;
+import software.amazon.awssdk.services.lambda.model.InvokeResponse;
+
+@Log4j2
+public class AwsSdkV2LambdaFunction<IN, OUT> implements LambdaFunction<IN, OUT> {
+
+  private final LambdaAsyncClient lambda;
+  private final ObjectReader reader;
+  private final ObjectWriter writer;
+  private final String functionName;
+
+  public AwsSdkV2LambdaFunction(
+      LambdaAsyncClient lambda, ObjectMapper mapper, Class<OUT> outputClass, String functionName) {
+
+    this.lambda = lambda;
+
+    this.reader = mapper.readerFor(outputClass);
+    this.writer = mapper.writer();
+
+    this.functionName = functionName;
+  }
+
+  @Override
+  public CompletableFuture<OUT> callAsync(IN input) {
+    CompletableFuture<OUT> response =
+        callLambda(InvocationType.RequestResponse, input).thenApply(this::deserialize);
+
+    response.thenAccept(r -> log.debug("response from {}: {}", functionName, r));
+
+    return response;
+  }
+
+  @Override
+  public CompletableFuture<Void> triggerAsync(IN input) {
+    CompletableFuture<InvokeResponse> response = callLambda(InvocationType.Event, input);
+
+    return response.thenAccept(
+        r -> log.debug("response from {}: {}", functionName, r.statusCode()));
+  }
+
+  private CompletableFuture<InvokeResponse> callLambda(InvocationType type, IN input) {
+    log.debug("calling '{}' as {} with payload: {}", functionName, type, input);
+
+    ByteBuffer payload = serialize(input);
+    InvokeRequest request =
+        InvokeRequest.builder()
+            .functionName(functionName)
+            .invocationType(type)
+            .payload(payload)
+            .build();
+
+    return lambda.invoke(request);
+  }
+
+  @SneakyThrows
+  private ByteBuffer serialize(IN input) {
+    return ByteBuffer.wrap(writer.writeValueAsBytes(input));
+  }
+
+  @SneakyThrows
+  private OUT deserialize(InvokeResponse response) {
+    return reader.readValue(new ByteBufferBackedInputStream(response.payload()));
+  }
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/lambda/JacksonRequestStreamHandler.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/lambda/JacksonRequestStreamHandler.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.Map;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.lang3.reflect.TypeUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Lambda RequestStreamHandler that allows for custom Jackson serialization of input/output types.
+ *
+ * <p>The default Lambda sandbox does not allow customization of the way that the function's inputs
+ * and outputs are serialized. This class provides a way to inject a Jackson {@link ObjectMapper}
+ * instance that can be configured as needed.
+ */
+@Log4j2
+public class JacksonRequestStreamHandler<IN, OUT> implements RequestStreamHandler {
+
+  private static final TypeVariable<Class<RequestHandler>>[] PARAMETERS =
+      RequestHandler.class.getTypeParameters();
+
+  private final ObjectReader reader;
+  private final ObjectWriter writer;
+  private final RequestHandler<IN, OUT> innerHandler;
+
+  @Autowired
+  public JacksonRequestStreamHandler(ObjectMapper mapper, RequestHandler<IN, OUT> innerHandler) {
+    this.innerHandler = innerHandler;
+
+    Map<TypeVariable<?>, Type> arguments =
+        TypeUtils.getTypeArguments(innerHandler.getClass(), RequestHandler.class);
+    Type inputType = arguments.get(PARAMETERS[0]);
+    Type outputType = arguments.get(PARAMETERS[1]);
+
+    this.reader = mapper.readerFor(mapper.constructType(inputType));
+    this.writer = mapper.writerFor(mapper.constructType(outputType));
+  }
+
+  @Override
+  public void handleRequest(InputStream input, OutputStream output, Context context)
+      throws IOException {
+    IN request = reader.readValue(input);
+    log.debug("Request: {}", request);
+
+    OUT response = innerHandler.handleRequest(request, context);
+    log.debug("Response: {}", response);
+
+    writer.writeValue(output, response);
+  }
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/lambda/LambdaFunction.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/lambda/LambdaFunction.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.lambda;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface LambdaFunction<IN, OUT> {
+
+  default OUT call(IN input) {
+    return callAsync(input).join();
+  }
+
+  CompletableFuture<OUT> callAsync(IN input);
+
+  CompletableFuture<Void> triggerAsync(IN input);
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/lambda/SpringLambdaHandler.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/lambda/SpringLambdaHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+@Log4j2
+public abstract class SpringLambdaHandler<APP> implements RequestStreamHandler {
+
+  private final ApplicationContext applicationContext;
+  private final RequestStreamHandler handler;
+
+  public SpringLambdaHandler(Class<APP> applicationClass) {
+    applicationContext = new AnnotationConfigApplicationContext(applicationClass);
+
+    handler = applicationContext.getBean(RequestStreamHandler.class);
+  }
+
+  @Override
+  public void handleRequest(InputStream input, OutputStream output, Context context)
+      throws IOException {
+    handler.handleRequest(input, output, context);
+  }
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/FakeDataService.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/FakeDataService.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling;
+
+import com.amazonaws.blox.dataservicemodel.v1.client.DataService;
+import com.amazonaws.blox.dataservicemodel.v1.exception.EnvironmentExistsException;
+import com.amazonaws.blox.dataservicemodel.v1.exception.EnvironmentNotFoundException;
+import com.amazonaws.blox.dataservicemodel.v1.exception.EnvironmentVersionNotFoundException;
+import com.amazonaws.blox.dataservicemodel.v1.exception.EnvironmentVersionOutdatedException;
+import com.amazonaws.blox.dataservicemodel.v1.exception.InvalidParameterException;
+import com.amazonaws.blox.dataservicemodel.v1.exception.ServiceException;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.CreateEnvironmentRequest;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.CreateEnvironmentResponse;
+import com.amazonaws.blox.dataservicemodel.v1.model.DeploymentConfiguration;
+import com.amazonaws.blox.dataservicemodel.v1.model.DeploymentType;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.DescribeTargetEnvironmentRevisionRequest;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.DescribeTargetEnvironmentRevisionResponse;
+import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentVersion;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListClustersRequest;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListClustersResponse;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListEnvironmentsRequest;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListEnvironmentsResponse;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.StartDeploymentRequest;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.StartDeploymentResponse;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Builder;
+
+@Builder
+/**
+ * Temporary fake data service for load-testing in Lambda
+ *
+ * <p>TODO: Move to end to end/load tests, or replace with fixture data
+ */
+public class FakeDataService implements DataService {
+  public static final List<String> GREEK =
+      Arrays.asList(
+          "Alpha",
+          "Beta",
+          "Gamma",
+          "Delta",
+          "Epsilon",
+          "Zeta",
+          "Eta",
+          "Theta",
+          "Iota",
+          "Kappa",
+          "Lambda",
+          "Mu",
+          "Nu",
+          "Xi",
+          "Omicron",
+          "Pi",
+          "Rho",
+          "Sigma",
+          "Tau",
+          "Upsilon",
+          "Phi",
+          "Chi",
+          "Psi",
+          "Omega",
+          "Ultra" /* not greek, but need 25 things */);
+  public static final List<String> THING = Arrays.asList("Blaster", "Boomer", "Slapper", "Zapper");
+  @Builder.Default private int clusters = 100;
+  @Builder.Default private int environmentsPerCluster = 10;
+
+  @Override
+  public CreateEnvironmentResponse createEnvironment(CreateEnvironmentRequest request)
+      throws EnvironmentExistsException, InvalidParameterException, ServiceException {
+    return null;
+  }
+
+  @Override
+  public StartDeploymentResponse startDeployment(StartDeploymentRequest request)
+      throws EnvironmentNotFoundException, EnvironmentVersionNotFoundException,
+          EnvironmentVersionOutdatedException, InvalidParameterException, ServiceException {
+    return null;
+  }
+
+  @Override
+  public ListEnvironmentsResponse listEnvironments(ListEnvironmentsRequest request) {
+    return new ListEnvironmentsResponse(
+        names("EnvironmentFor" + request.getClusterArn())
+            .stream()
+            .limit(environmentsPerCluster)
+            .collect(Collectors.toList()));
+  }
+
+  @Override
+  public ListClustersResponse listClusters(ListClustersRequest request) {
+    return new ListClustersResponse(
+        names("Cluster").stream().limit(clusters).collect(Collectors.toList()));
+  }
+
+  @Override
+  public DescribeTargetEnvironmentRevisionResponse describeTargetEnvironmentRevision(
+      DescribeTargetEnvironmentRevisionRequest request) {
+    return new DescribeTargetEnvironmentRevisionResponse(
+        EnvironmentVersion.builder()
+            .deploymentType(DeploymentType.SingleTask)
+            .deploymentConfiguration(DeploymentConfiguration.builder().build())
+            .build());
+  }
+
+  private List<String> names(String suffix) {
+    return GREEK
+        .stream()
+        .flatMap(g -> THING.stream().map(t -> g + t + suffix))
+        .collect(Collectors.toList());
+  }
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/SchedulingApplication.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/SchedulingApplication.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling;
+
+import com.amazonaws.blox.dataservicemodel.v1.client.DataService;
+import com.amazonaws.blox.lambda.JacksonRequestStreamHandler;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+import software.amazon.awssdk.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.services.lambda.LambdaAsyncClient;
+
+/** Common beans required by all Scheduling lambda functions. */
+public abstract class SchedulingApplication {
+
+  static {
+    // HACK: Disable IPv6 for the current JVM, since the Netty `epoll` driver fails in a Lambda function if IPv6 is enabled.
+    // Remove after https://github.com/aws/aws-sdk-java-v2/issues/193 is fixed.
+    System.setProperty("java.net.preferIPv4Stack", "true");
+  }
+
+  @Bean
+  public <IN, OUT> RequestStreamHandler streamHandler(RequestHandler<IN, OUT> innerHandler) {
+    return new JacksonRequestStreamHandler<>(mapper(), innerHandler);
+  }
+
+  /** The X-Ray Trace ID provided by the Lambda runtime environment. */
+  @Value("${_X_AMZN_TRACE_ID}")
+  public String traceId;
+
+  @Bean
+  @Profile("!test")
+  public LambdaAsyncClient lambdaClient() {
+    // add trace ID to downstream calls, for X-Ray integration
+    ClientOverrideConfiguration configuration =
+        ClientOverrideConfiguration.builder()
+            .addAdditionalHttpHeader("X-Amzn-Trace-Id", traceId)
+            .build();
+
+    return LambdaAsyncClient.builder().overrideConfiguration(configuration).build();
+  }
+
+  @Bean
+  public ObjectMapper mapper() {
+    return new ObjectMapper().findAndRegisterModules();
+  }
+
+  @Bean
+  public DataService dataService() {
+    return FakeDataService.builder().build();
+  }
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/manager/ManagerApplication.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/manager/ManagerApplication.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.manager;
+
+import com.amazonaws.blox.lambda.LambdaFunction;
+import com.amazonaws.blox.lambda.AwsSdkV2LambdaFunction;
+import com.amazonaws.blox.scheduling.SchedulingApplication;
+import com.amazonaws.blox.scheduling.scheduler.SchedulerInput;
+import com.amazonaws.blox.scheduling.scheduler.SchedulerOutput;
+import com.amazonaws.blox.scheduling.state.ECSStateClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan("com.amazonaws.blox.scheduling.manager")
+public class ManagerApplication extends SchedulingApplication {
+
+  // Wired in through environment variable in CloudFormation template
+  @Value("${scheduler_function_name}")
+  String schedulerFunctionName;
+
+  @Bean
+  public LambdaFunction<SchedulerInput, SchedulerOutput> scheduler() {
+    return new AwsSdkV2LambdaFunction<>(
+        lambdaClient(), mapper(), SchedulerOutput.class, schedulerFunctionName);
+  }
+
+  @Bean
+  public ECSStateClient ecsState() {
+    return new ECSStateClient();
+  }
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/manager/ManagerEntrypoint.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/manager/ManagerEntrypoint.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.manager;
+
+import com.amazonaws.blox.lambda.SpringLambdaHandler;
+
+public class ManagerEntrypoint extends SpringLambdaHandler<ManagerApplication> {
+
+  public ManagerEntrypoint() {
+    super(ManagerApplication.class);
+  }
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/manager/ManagerHandler.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/manager/ManagerHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.manager;
+
+import com.amazonaws.blox.dataservicemodel.v1.client.DataService;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListEnvironmentsRequest;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListEnvironmentsResponse;
+import com.amazonaws.blox.lambda.LambdaFunction;
+import com.amazonaws.blox.scheduling.scheduler.SchedulerInput;
+import com.amazonaws.blox.scheduling.scheduler.SchedulerOutput;
+import com.amazonaws.blox.scheduling.state.ClusterSnapshot;
+import com.amazonaws.blox.scheduling.state.ECSState;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.spotify.futures.CompletableFutures;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class ManagerHandler implements RequestHandler<ManagerInput, ManagerOutput> {
+  private final DataService data;
+  private final ECSState ecs;
+  private final LambdaFunction<SchedulerInput, SchedulerOutput> scheduler;
+
+  @Override
+  public ManagerOutput handleRequest(ManagerInput input, Context context) {
+    ListEnvironmentsResponse r =
+        data.listEnvironments(new ListEnvironmentsRequest(input.getClusterArn()));
+    List<String> environments = r.getEnvironmentIds();
+
+    ClusterSnapshot state = ecs.snapshotState(input.getClusterArn());
+
+    Stream<CompletableFuture<SchedulerOutput>> pendingRequests =
+        environments
+            .stream()
+            .map(environmentId -> scheduler.callAsync(new SchedulerInput(state, environmentId)));
+
+    List<SchedulerOutput> outputs = pendingRequests.collect(CompletableFutures.joinList()).join();
+
+    return new ManagerOutput(input.getClusterArn(), outputs);
+  }
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/manager/ManagerInput.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/manager/ManagerInput.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.manager;
+
+import lombok.Data;
+
+@Data
+public class ManagerInput {
+  private final String clusterArn;
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/manager/ManagerOutput.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/manager/ManagerOutput.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.manager;
+
+import com.amazonaws.blox.scheduling.scheduler.SchedulerOutput;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class ManagerOutput {
+  private final String clusterArn;
+  private final List<SchedulerOutput> scheduleResults;
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/reconciler/CloudWatchEvent.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/reconciler/CloudWatchEvent.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.reconciler;
+
+import com.amazonaws.regions.Regions;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.List;
+import lombok.Data;
+
+/**
+ * Representation of an Event from Cloudwatch.
+ *
+ * <p>See http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html for details.
+ *
+ * @param <T> The type of the "detail" field.
+ */
+@Data
+public class CloudWatchEvent<T> {
+
+  private String version;
+  private String id;
+  private String account;
+  private String source;
+  private Instant time;
+  private Regions region;
+  private List<String> resources;
+  private T detail;
+
+  @JsonProperty("detail-type")
+  private String detailType;
+
+  /**
+   * Setter for Jackson to deserialize Regions enum from string
+   *
+   * @param region
+   */
+  public void setRegion(String region) {
+    this.region = Regions.fromName(region);
+  }
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/reconciler/ReconcilerApplication.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/reconciler/ReconcilerApplication.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.reconciler;
+
+import com.amazonaws.blox.lambda.AwsSdkV2LambdaFunction;
+import com.amazonaws.blox.lambda.LambdaFunction;
+import com.amazonaws.blox.scheduling.SchedulingApplication;
+import com.amazonaws.blox.scheduling.manager.ManagerInput;
+import com.amazonaws.blox.scheduling.manager.ManagerOutput;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan("com.amazonaws.blox.scheduling.reconciler")
+public class ReconcilerApplication extends SchedulingApplication {
+
+  // Wired in through environment variable in CloudFormation template
+  @Value("${manager_function_name}")
+  String managerFunctionName;
+
+  @Bean
+  public LambdaFunction<ManagerInput, ManagerOutput> manager() {
+    return new AwsSdkV2LambdaFunction<>(
+        lambdaClient(), mapper(), ManagerOutput.class, managerFunctionName);
+  }
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/reconciler/ReconcilerEntrypoint.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/reconciler/ReconcilerEntrypoint.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.reconciler;
+
+import com.amazonaws.blox.lambda.SpringLambdaHandler;
+
+public class ReconcilerEntrypoint extends SpringLambdaHandler<ReconcilerApplication> {
+
+  public ReconcilerEntrypoint() {
+    super(ReconcilerApplication.class);
+  }
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/reconciler/ReconcilerHandler.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/reconciler/ReconcilerHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.reconciler;
+
+import com.amazonaws.blox.dataservicemodel.v1.client.DataService;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListClustersRequest;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListClustersResponse;
+import com.amazonaws.blox.lambda.LambdaFunction;
+import com.amazonaws.blox.scheduling.manager.ManagerInput;
+import com.amazonaws.blox.scheduling.manager.ManagerOutput;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.spotify.futures.CompletableFutures;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class ReconcilerHandler implements RequestHandler<CloudWatchEvent<Map>, Void> {
+  final DataService dataService;
+  final LambdaFunction<ManagerInput, ManagerOutput> stateFunction;
+
+  @Override
+  public Void handleRequest(CloudWatchEvent<Map> input, Context context) {
+    ListClustersResponse r = dataService.listClusters(new ListClustersRequest());
+    List<String> clusters = r.getClusterArns();
+
+    clusters
+        .stream()
+        .map(c -> stateFunction.triggerAsync(new ManagerInput(c)))
+        .collect(CompletableFutures.joinList())
+        .join();
+
+    return null;
+  }
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/scheduler/SchedulerApplication.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/scheduler/SchedulerApplication.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.scheduler;
+
+import com.amazonaws.blox.scheduling.SchedulingApplication;
+import com.amazonaws.blox.scheduling.scheduler.engine.SchedulerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.services.ecs.ECSAsyncClient;
+
+@Configuration
+@ComponentScan("com.amazonaws.blox.scheduling.scheduler")
+public class SchedulerApplication extends SchedulingApplication {
+  @Bean
+  public ECSAsyncClient ecs() {
+    return ECSAsyncClient.builder().build();
+  }
+
+  @Bean
+  public SchedulerFactory schedulerFactory() {
+    return new SchedulerFactory();
+  }
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/scheduler/SchedulerEntrypoint.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/scheduler/SchedulerEntrypoint.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.scheduler;
+
+import com.amazonaws.blox.lambda.SpringLambdaHandler;
+
+public class SchedulerEntrypoint extends SpringLambdaHandler<SchedulerApplication> {
+
+  public SchedulerEntrypoint() {
+    super(SchedulerApplication.class);
+  }
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/scheduler/SchedulerHandler.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/scheduler/SchedulerHandler.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.scheduler;
+
+import com.amazonaws.blox.dataservicemodel.v1.client.DataService;
+import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentVersion;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.DescribeTargetEnvironmentRevisionResponse;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.DescribeTargetEnvironmentRevisionRequest;
+import com.amazonaws.blox.scheduling.scheduler.engine.Scheduler;
+import com.amazonaws.blox.scheduling.scheduler.engine.SchedulerFactory;
+import com.amazonaws.blox.scheduling.scheduler.engine.SchedulingAction;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.spotify.futures.CompletableFutures;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.ecs.ECSAsyncClient;
+
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class SchedulerHandler implements RequestHandler<SchedulerInput, SchedulerOutput> {
+  private final DataService data;
+  private final ECSAsyncClient ecs;
+  private final SchedulerFactory schedulerFactory;
+
+  @Override
+  public SchedulerOutput handleRequest(SchedulerInput input, Context context) {
+    log.debug("Request: {}", input);
+
+    DescribeTargetEnvironmentRevisionResponse r =
+        data.describeTargetEnvironmentRevision(
+            new DescribeTargetEnvironmentRevisionRequest(input.getEnvironmentId()));
+    EnvironmentVersion revision = r.getEnvironmentVersion();
+
+    Scheduler s = schedulerFactory.schedulerFor(revision.getDeploymentType());
+
+    List<SchedulingAction> actions = s.schedule(input.getSnapshot(), revision);
+
+    List<Boolean> outcomes =
+        actions.stream().map(a -> a.execute(ecs)).collect(CompletableFutures.joinList()).join();
+
+    Map<Boolean, Long> outcomeCounts =
+        outcomes
+            .stream()
+            .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+
+    return new SchedulerOutput(
+        input.getSnapshot().getClusterArn(),
+        input.getEnvironmentId(),
+        outcomeCounts.getOrDefault(false, 0L),
+        outcomeCounts.getOrDefault(true, 0L));
+  }
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/scheduler/SchedulerInput.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/scheduler/SchedulerInput.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.scheduler;
+
+import com.amazonaws.blox.scheduling.state.ClusterSnapshot;
+import lombok.Data;
+
+@Data
+public class SchedulerInput {
+  final ClusterSnapshot snapshot;
+  final String environmentId;
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/scheduler/SchedulerOutput.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/scheduler/SchedulerOutput.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.scheduler;
+
+import lombok.Data;
+
+@Data
+public class SchedulerOutput {
+  private final String clusterArn;
+  private final String environmentId;
+
+  private final long successfulActions;
+  private final long failedActions;
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/scheduler/engine/Scheduler.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/scheduler/engine/Scheduler.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.scheduler.engine;
+
+import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentVersion;
+import com.amazonaws.blox.scheduling.state.ClusterSnapshot;
+import java.util.List;
+
+public interface Scheduler {
+
+  List<SchedulingAction> schedule(ClusterSnapshot snapshot, EnvironmentVersion environment);
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/scheduler/engine/SchedulerFactory.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/scheduler/engine/SchedulerFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.scheduler.engine;
+
+import com.amazonaws.blox.dataservicemodel.v1.model.DeploymentType;
+
+public class SchedulerFactory {
+
+  public Scheduler schedulerFor(DeploymentType deploymentType) {
+    switch (deploymentType) {
+      case SingleTask:
+        return new SingleTaskScheduler();
+      default:
+        throw new RuntimeException("Deployment method not supported");
+    }
+  }
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/scheduler/engine/SchedulingAction.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/scheduler/engine/SchedulingAction.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.scheduler.engine;
+
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.services.ecs.ECSAsyncClient;
+
+public interface SchedulingAction {
+  // TODO: We probably want to give this code an ECS facade that can only start/stop tasks in a
+  //       single cluster, instead of the full ECS API.
+  CompletableFuture<Boolean> execute(ECSAsyncClient ecs);
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/scheduler/engine/SingleTaskScheduler.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/scheduler/engine/SingleTaskScheduler.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.scheduler.engine;
+
+import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentVersion;
+import com.amazonaws.blox.scheduling.state.ClusterSnapshot;
+import com.amazonaws.blox.scheduling.state.ClusterSnapshot.ContainerInstance;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map.Entry;
+
+/**
+ * Temporary scheduler implementation that just starts a single task on the first instance in the
+ * snapshot.
+ */
+public class SingleTaskScheduler implements Scheduler {
+
+  @Override
+  public List<SchedulingAction> schedule(ClusterSnapshot snapshot, EnvironmentVersion environment) {
+    // Only run a Task on the first ContainerInstance in the snapshot:
+    for (Entry<String, ContainerInstance> entry : snapshot.getInstances().entrySet()) {
+      return Arrays.asList(
+          new StartTask(snapshot.getClusterArn(), entry.getKey(), environment.getTaskDefinition()));
+    }
+    return Collections.emptyList();
+  }
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/scheduler/engine/StartTask.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/scheduler/engine/StartTask.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.scheduler.engine;
+
+import java.util.concurrent.CompletableFuture;
+import lombok.Value;
+import software.amazon.awssdk.services.ecs.ECSAsyncClient;
+import software.amazon.awssdk.services.ecs.model.StartTaskRequest;
+import software.amazon.awssdk.services.ecs.model.StartTaskResponse;
+
+@Value
+public class StartTask implements SchedulingAction {
+  private final String clusterArn;
+  private final String containerInstanceArn;
+  private final String taskDefinitionArn;
+
+  @Override
+  public CompletableFuture<Boolean> execute(ECSAsyncClient ecs) {
+    // TODO: This will probably require setting the task group to the environment ID too
+    CompletableFuture<StartTaskResponse> pendingRequest =
+        ecs.startTask(
+            StartTaskRequest.builder()
+                .cluster(clusterArn)
+                .containerInstances(containerInstanceArn)
+                .taskDefinition(taskDefinitionArn)
+                .build());
+
+    // TODO: We probably need richer error reporting than a Boolean
+    return pendingRequest.thenApply(startTaskResponse -> startTaskResponse.failures().size() == 0);
+  }
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/state/ClusterSnapshot.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/state/ClusterSnapshot.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.state;
+
+import java.util.Map;
+import lombok.Data;
+import lombok.Value;
+
+@Data
+public class ClusterSnapshot {
+  private final String clusterArn;
+  private final Map<String, Task> tasks;
+  private final Map<String, ContainerInstance> instances;
+
+  @Value
+  public static class Task {
+    private final String arn;
+    private final String containerInstanceArn;
+    private final String taskDefinitionArn;
+    private final String status;
+  }
+
+  @Value
+  public static class ContainerInstance {
+    private final String arn;
+  }
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/state/ECSState.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/state/ECSState.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.state;
+
+public interface ECSState {
+
+  ClusterSnapshot snapshotState(String clusterArn);
+}

--- a/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/state/ECSStateClient.java
+++ b/scheduling-manager/src/main/java/com/amazonaws/blox/scheduling/state/ECSStateClient.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.state;
+
+import java.util.Collections;
+import lombok.SneakyThrows;
+
+/**
+ * Temporary fake implementation of ECS State client that just takes time and returns an empty
+ * cluster.
+ */
+public class ECSStateClient implements ECSState {
+
+  @Override
+  @SneakyThrows
+  public ClusterSnapshot snapshotState(String clusterArn) {
+    Thread.sleep(5000); // this will take a while
+    return new ClusterSnapshot(clusterArn, Collections.emptyMap(), Collections.emptyMap());
+  }
+}

--- a/scheduling-manager/src/main/resources/log4j2.xml
+++ b/scheduling-manager/src/main/resources/log4j2.xml
@@ -6,6 +6,9 @@
   </Lambda>
 </Appenders>
 <Loggers>
+  <Root level="warn">
+    <AppenderRef ref="LambdaAppender" />
+  </Root>
   <Logger name="com.amazonaws.blox" level="debug" additivity="false">
     <AppenderRef ref="LambdaAppender" />
   </Logger>

--- a/scheduling-manager/src/test/java/com/amazonaws/blox/lambda/AwsSdkV2LambdaFunctionTest.java
+++ b/scheduling-manager/src/test/java/com/amazonaws/blox/lambda/AwsSdkV2LambdaFunctionTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.lambda;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import lombok.Data;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.services.lambda.LambdaAsyncClient;
+import software.amazon.awssdk.services.lambda.model.InvocationType;
+import software.amazon.awssdk.services.lambda.model.InvokeRequest;
+import software.amazon.awssdk.services.lambda.model.InvokeResponse;
+
+public class AwsSdkV2LambdaFunctionTest {
+
+  private final ArgumentCaptor<InvokeRequest> requestArgument =
+      ArgumentCaptor.forClass(InvokeRequest.class);
+  private final ObjectMapper mapper = new ObjectMapper();
+  private final LambdaAsyncClient client = mock(LambdaAsyncClient.class);
+  private final AwsSdkV2LambdaFunction<TestInput, TestOutput> function =
+      new AwsSdkV2LambdaFunction<>(client, mapper, TestOutput.class, "TestFunction");
+
+  @Before
+  public void defaultStubs() throws Exception {
+    when(client.invoke(any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                InvokeResponse.builder()
+                    .payload(ByteBuffer.wrap(mapper.writeValueAsBytes(new TestOutput("value"))))
+                    .build()));
+  }
+
+  @Test
+  public void deserializesOutputsUsingMapper() throws Exception {
+    TestOutput output = function.call(new TestInput("test"));
+    assertThat(output.getOutput(), equalTo("value"));
+  }
+
+  @Test
+  public void serializesInputsUsingMapper() throws Exception {
+    TestOutput output = function.call(new TestInput("test"));
+    verify(client).invoke(requestArgument.capture());
+
+    ByteBuffer actualPayload = requestArgument.getValue().payload();
+    assertThat(
+        mapper
+            .readValue(new ByteBufferBackedInputStream(actualPayload), TestInput.class)
+            .getInput(),
+        equalTo("test"));
+  }
+
+  @Test
+  public void passesCorrectFunctionName() {
+    function.call(new TestInput("test"));
+    verify(client).invoke(requestArgument.capture());
+
+    assertThat(requestArgument.getValue().functionName(), equalTo("TestFunction"));
+  }
+
+  @Test
+  public void callUsesRequestReply() {
+    function.callAsync(new TestInput("test")).join();
+
+    verify(client).invoke(requestArgument.capture());
+    assertThat(
+        requestArgument.getValue().invocationType(),
+        equalTo(InvocationType.RequestResponse.toString()));
+  }
+
+  @Test
+  public void triggerUsesEventInvocation() {
+    function.triggerAsync(new TestInput("test")).join();
+
+    verify(client).invoke(requestArgument.capture());
+    assertThat(
+        requestArgument.getValue().invocationType(), equalTo(InvocationType.Event.toString()));
+  }
+
+  @Data
+  static class TestInput {
+
+    final String input;
+  }
+
+  @Data
+  static class TestOutput {
+
+    final String output;
+  }
+}

--- a/scheduling-manager/src/test/java/com/amazonaws/blox/lambda/JacksonRequestStreamHandlerTest.java
+++ b/scheduling-manager/src/test/java/com/amazonaws/blox/lambda/JacksonRequestStreamHandlerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.lambda;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import lombok.Data;
+import org.junit.Test;
+
+public class JacksonRequestStreamHandlerTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  public void roundtripsInputsAndOutputs() throws Exception {
+    RequestStreamHandler handler = new JacksonRequestStreamHandler<>(mapper, new TestHandler());
+
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    handler.handleRequest(
+        new ByteArrayInputStream("{\"input\":\"input\"}".getBytes()), outputStream, null);
+
+    assertThat(outputStream.toString(), is("{\"output\":\"input\"}"));
+  }
+
+  abstract static class BaseHandler implements RequestHandler<FakeInput, FakeOutput> {}
+
+  static class TestHandler extends BaseHandler {
+
+    @Override
+    public FakeOutput handleRequest(FakeInput input, Context context) {
+      return new FakeOutput(input.getInput());
+    }
+  }
+
+  @Data
+  static class FakeInput {
+
+    private final String input;
+  }
+
+  @Data
+  static class FakeOutput {
+
+    private final String output;
+  }
+}

--- a/scheduling-manager/src/test/java/com/amazonaws/blox/lambda/TestLambdaFunction.java
+++ b/scheduling-manager/src/test/java/com/amazonaws/blox/lambda/TestLambdaFunction.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TestLambdaFunction<IN, OUT> implements LambdaFunction<IN, OUT> {
+
+  final RequestHandler<IN, OUT> handler;
+
+  @Override
+  public CompletableFuture<OUT> callAsync(IN input) {
+    return CompletableFuture.supplyAsync(() -> handler.handleRequest(input, fakeContext()));
+  }
+
+  @Override
+  public CompletableFuture<Void> triggerAsync(IN input) {
+    return CompletableFuture.runAsync(() -> handler.handleRequest(input, fakeContext()));
+  }
+
+  private Context fakeContext() {
+    return null;
+  }
+}

--- a/scheduling-manager/src/test/java/com/amazonaws/blox/scheduling/LambdaHandlerTestCase.java
+++ b/scheduling-manager/src/test/java/com/amazonaws/blox/scheduling/LambdaHandlerTestCase.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling;
+
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Paths;
+import java.util.stream.Collectors;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@ActiveProfiles("test")
+public abstract class LambdaHandlerTestCase {
+
+  @Autowired protected RequestStreamHandler handler;
+
+  public String callHandler(String input) throws IOException {
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(input.getBytes());
+    return callHandler(inputStream);
+  }
+
+  protected String callHandler(InputStream inputStream) throws IOException {
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+    handler.handleRequest(inputStream, outputStream, null);
+
+    return outputStream.toString();
+  }
+
+  protected InputStream fixture(String path) throws IOException {
+    return new ClassPathResource(Paths.get("fixtures", path).toString()).getInputStream();
+  }
+
+  protected String fixtureAsString(String path) throws IOException {
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(fixture(path)))) {
+      return reader.lines().collect(Collectors.joining("\n"));
+    }
+  }
+}

--- a/scheduling-manager/src/test/java/com/amazonaws/blox/scheduling/SchedulingSystemTest.java
+++ b/scheduling-manager/src/test/java/com/amazonaws/blox/scheduling/SchedulingSystemTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.blox.dataservicemodel.v1.client.DataService;
+import com.amazonaws.blox.dataservicemodel.v1.model.DeploymentType;
+import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentVersion;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.DescribeTargetEnvironmentRevisionResponse;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.DescribeTargetEnvironmentRevisionRequest;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListClustersResponse;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListEnvironmentsRequest;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListEnvironmentsResponse;
+import com.amazonaws.blox.lambda.TestLambdaFunction;
+import com.amazonaws.blox.scheduling.manager.ManagerHandler;
+import com.amazonaws.blox.scheduling.manager.ManagerInput;
+import com.amazonaws.blox.scheduling.manager.ManagerOutput;
+import com.amazonaws.blox.scheduling.reconciler.CloudWatchEvent;
+import com.amazonaws.blox.scheduling.reconciler.ReconcilerHandler;
+import com.amazonaws.blox.scheduling.scheduler.SchedulerHandler;
+import com.amazonaws.blox.scheduling.scheduler.SchedulerInput;
+import com.amazonaws.blox.scheduling.scheduler.SchedulerOutput;
+import com.amazonaws.blox.scheduling.scheduler.engine.SchedulerFactory;
+import com.amazonaws.blox.scheduling.state.ClusterSnapshot;
+import com.amazonaws.blox.scheduling.state.ClusterSnapshot.ContainerInstance;
+import com.amazonaws.blox.scheduling.state.ECSState;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+import lombok.extern.log4j.Log4j2;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.services.ecs.ECSAsyncClient;
+import software.amazon.awssdk.services.ecs.model.StartTaskRequest;
+import software.amazon.awssdk.services.ecs.model.StartTaskResponse;
+
+@Log4j2
+public class SchedulingSystemTest {
+
+  private static final String CLUSTER_ARN = "arn:::::cluster1";
+  private static final String ENVIRONMENT_ARN = "arn:::::environment1";
+  private static final String INSTANCE_ARN = "arn:::::instance1";
+  private static final String TASKDEF_ARN = "arn:::::task:1";
+
+  private final ClusterSnapshot snapshot =
+      new ClusterSnapshot(CLUSTER_ARN, Collections.emptyMap(), new HashMap<>());
+
+  private final DataService dataService = mock(DataService.class);
+
+  private final ECSState ecsState = mock(ECSState.class);
+  private final ECSAsyncClient ecs = mock(ECSAsyncClient.class);
+
+  private final SchedulerFactory schedulerFactory = new SchedulerFactory();
+  private final SchedulerHandler scheduler =
+      new SchedulerHandler(dataService, ecs, schedulerFactory);
+  private final TestLambdaFunction<SchedulerInput, SchedulerOutput> schedulerClient =
+      new TestLambdaFunction<>(scheduler);
+
+  private final ManagerHandler manager = new ManagerHandler(dataService, ecsState, schedulerClient);
+  private final TestLambdaFunction<ManagerInput, ManagerOutput> managerClient =
+      new TestLambdaFunction<>(manager);
+
+  @Test
+  public void runSingleReconciliation() {
+    when(dataService.listClusters(any()))
+        .thenReturn(new ListClustersResponse(Arrays.asList(CLUSTER_ARN)));
+
+    when(ecsState.snapshotState(CLUSTER_ARN)).thenReturn(snapshot).getMock();
+
+    when(dataService.listEnvironments(new ListEnvironmentsRequest(CLUSTER_ARN)))
+        .thenReturn(new ListEnvironmentsResponse(Arrays.asList(ENVIRONMENT_ARN)));
+
+    when(dataService.describeTargetEnvironmentRevision(
+            new DescribeTargetEnvironmentRevisionRequest(ENVIRONMENT_ARN)))
+        .thenReturn(
+            new DescribeTargetEnvironmentRevisionResponse(
+                EnvironmentVersion.builder()
+                    .deploymentType(DeploymentType.SingleTask)
+                    .taskDefinition(TASKDEF_ARN)
+                    .build()));
+
+    when(ecs.startTask(any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(StartTaskResponse.builder().failures().build()));
+
+    snapshot.getInstances().put(INSTANCE_ARN, new ContainerInstance(INSTANCE_ARN));
+
+    ReconcilerHandler recon = new ReconcilerHandler(dataService, managerClient);
+    recon.handleRequest(new CloudWatchEvent<>(), null);
+
+    ArgumentCaptor<StartTaskRequest> startArgument =
+        ArgumentCaptor.forClass(StartTaskRequest.class);
+    verify(ecs).startTask(startArgument.capture());
+
+    StartTaskRequest request = startArgument.getValue();
+    assertThat(request.cluster(), equalTo(CLUSTER_ARN));
+    assertThat(request.containerInstances(), hasItem(INSTANCE_ARN));
+    assertThat(request.taskDefinition(), equalTo(TASKDEF_ARN));
+  }
+}

--- a/scheduling-manager/src/test/java/com/amazonaws/blox/scheduling/manager/ManagerEntrypointTest.java
+++ b/scheduling-manager/src/test/java/com/amazonaws/blox/scheduling/manager/ManagerEntrypointTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.manager;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.blox.dataservicemodel.v1.client.DataService;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListEnvironmentsResponse;
+import com.amazonaws.blox.lambda.LambdaFunction;
+import com.amazonaws.blox.lambda.TestLambdaFunction;
+import com.amazonaws.blox.scheduling.LambdaHandlerTestCase;
+import com.amazonaws.blox.scheduling.manager.ManagerEntrypointTest.TestConfig;
+import com.amazonaws.blox.scheduling.scheduler.SchedulerInput;
+import com.amazonaws.blox.scheduling.scheduler.SchedulerOutput;
+import com.amazonaws.blox.scheduling.state.ClusterSnapshot;
+import com.amazonaws.blox.scheduling.state.ECSState;
+import java.util.Collections;
+import org.junit.Test;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+
+@ContextConfiguration(classes = TestConfig.class)
+public class ManagerEntrypointTest extends LambdaHandlerTestCase {
+
+  @Test
+  public void convertsInputsAndOutputsFromJson() throws Exception {
+    String result = callHandler(fixture("handlers/Manager.input.json"));
+    assertThat(result, is(fixtureAsString("handlers/Manager.output.json")));
+  }
+
+  @Configuration
+  @Import(ManagerApplication.class)
+  public static class TestConfig {
+
+    @Bean
+    public DataService dataService() {
+      return when(mock(DataService.class).listEnvironments(any()))
+          .thenReturn(new ListEnvironmentsResponse(Collections.singletonList("SomeEnvironment")))
+          .getMock();
+    }
+
+    @Bean
+    public ECSState ecsState() {
+      return when(mock(ECSState.class).snapshotState(any()))
+          .thenReturn(
+              new ClusterSnapshot(
+                  "arn:aws:ecs:us-east-1:1234:cluster/default",
+                  Collections.emptyMap(),
+                  Collections.emptyMap()))
+          .getMock();
+    }
+
+    @Bean
+    public LambdaFunction<SchedulerInput, SchedulerOutput> scheduler() {
+      return new TestLambdaFunction<>(
+          (input, context) ->
+              new SchedulerOutput(
+                  input.getSnapshot().getClusterArn(), input.getEnvironmentId(), 0L, 0L));
+    }
+  }
+}

--- a/scheduling-manager/src/test/java/com/amazonaws/blox/scheduling/manager/ManagerHandlerTest.java
+++ b/scheduling-manager/src/test/java/com/amazonaws/blox/scheduling/manager/ManagerHandlerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.manager;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.blox.dataservicemodel.v1.client.DataService;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListEnvironmentsRequest;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListEnvironmentsResponse;
+import com.amazonaws.blox.lambda.LambdaFunction;
+import com.amazonaws.blox.scheduling.scheduler.SchedulerInput;
+import com.amazonaws.blox.scheduling.scheduler.SchedulerOutput;
+import com.amazonaws.blox.scheduling.state.ECSState;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ManagerHandlerTest {
+  public static final String CLUSTER_ARN = "arn:::::cluster1";
+  public static final String FIRST_ENVIRONMENT_ARN = "arn:::::environment1";
+  public static final String SECOND_ENVIRONMENT_ARN = "arn:::::environment2";
+
+  private ArgumentCaptor<SchedulerInput> schedulerArgument =
+      ArgumentCaptor.forClass(SchedulerInput.class);
+  @Mock private LambdaFunction<SchedulerInput, SchedulerOutput> scheduler;
+  @Mock private ECSState ecs;
+  @Mock private DataService dataService;
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void invokesSchedulerForAllEnvironments() {
+    when(dataService.listEnvironments(new ListEnvironmentsRequest(CLUSTER_ARN)))
+        .thenReturn(
+            new ListEnvironmentsResponse(
+                Arrays.asList(FIRST_ENVIRONMENT_ARN, SECOND_ENVIRONMENT_ARN)));
+
+    when(scheduler.callAsync(schedulerArgument.capture()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new SchedulerOutput(CLUSTER_ARN, "arn:::::environment1", 1, 1)));
+
+    ManagerHandler handler = new ManagerHandler(dataService, ecs, scheduler);
+    ManagerOutput managerOutput = handler.handleRequest(new ManagerInput(CLUSTER_ARN), null);
+
+    assertThat(
+        schedulerArgument.getAllValues(),
+        contains(
+            hasProperty("environmentId", is(FIRST_ENVIRONMENT_ARN)),
+            hasProperty("environmentId", is(SECOND_ENVIRONMENT_ARN))));
+  }
+}

--- a/scheduling-manager/src/test/java/com/amazonaws/blox/scheduling/reconciler/ReconcilerEntrypointTest.java
+++ b/scheduling-manager/src/test/java/com/amazonaws/blox/scheduling/reconciler/ReconcilerEntrypointTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.reconciler;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.amazonaws.blox.lambda.LambdaFunction;
+import com.amazonaws.blox.lambda.TestLambdaFunction;
+import com.amazonaws.blox.scheduling.LambdaHandlerTestCase;
+import com.amazonaws.blox.scheduling.manager.ManagerInput;
+import com.amazonaws.blox.scheduling.manager.ManagerOutput;
+import com.amazonaws.blox.scheduling.reconciler.ReconcilerEntrypointTest.TestConfig;
+import java.util.Collections;
+import org.junit.Test;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+
+@ContextConfiguration(classes = TestConfig.class)
+public class ReconcilerEntrypointTest extends LambdaHandlerTestCase {
+
+  @Test
+  public void convertsInputsAndOutputsFromJson() throws Exception {
+    String result = callHandler(fixture("handlers/Reconciler.input.json"));
+    assertThat(result, is("null"));
+  }
+
+  @Configuration
+  @Import(ReconcilerApplication.class)
+  public static class TestConfig {
+
+    @Bean
+    public LambdaFunction<ManagerInput, ManagerOutput> manager() {
+      return new TestLambdaFunction<>(
+          (input, context) -> new ManagerOutput(input.getClusterArn(), Collections.emptyList()));
+    }
+  }
+}

--- a/scheduling-manager/src/test/java/com/amazonaws/blox/scheduling/reconciler/ReconcilerHandlerTest.java
+++ b/scheduling-manager/src/test/java/com/amazonaws/blox/scheduling/reconciler/ReconcilerHandlerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.reconciler;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.blox.dataservicemodel.v1.client.DataService;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListClustersResponse;
+import com.amazonaws.blox.lambda.LambdaFunction;
+import com.amazonaws.blox.scheduling.manager.ManagerInput;
+import com.amazonaws.blox.scheduling.manager.ManagerOutput;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReconcilerHandlerTest {
+
+  public static final String FIRST_CLUSTER_ARN = "arn:::::cluster1";
+  public static final String SECOND_CLUSTER_ARN = "arn:::::cluster2";
+
+  private ArgumentCaptor<ManagerInput> input = ArgumentCaptor.forClass(ManagerInput.class);
+  @Mock private DataService data;
+  @Mock private LambdaFunction<ManagerInput, ManagerOutput> manager;
+
+  @Test
+  public void invokesManagerAsynchronouslyForAllClusters() {
+    when(data.listClusters(any()))
+        .thenReturn(new ListClustersResponse(Arrays.asList(FIRST_CLUSTER_ARN, SECOND_CLUSTER_ARN)));
+
+    when(manager.triggerAsync(input.capture())).thenReturn(CompletableFuture.completedFuture(null));
+
+    ReconcilerHandler handler = new ReconcilerHandler(data, manager);
+    handler.handleRequest(new CloudWatchEvent<>(), null);
+
+    assertThat(
+        input.getAllValues(),
+        hasItems(new ManagerInput(FIRST_CLUSTER_ARN), new ManagerInput(SECOND_CLUSTER_ARN)));
+  }
+}

--- a/scheduling-manager/src/test/java/com/amazonaws/blox/scheduling/scheduler/SchedulerEntrypointTest.java
+++ b/scheduling-manager/src/test/java/com/amazonaws/blox/scheduling/scheduler/SchedulerEntrypointTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.scheduler;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.blox.scheduling.LambdaHandlerTestCase;
+import com.amazonaws.blox.scheduling.scheduler.SchedulerEntrypointTest.TestConfig;
+import com.amazonaws.blox.scheduling.scheduler.engine.SchedulerFactory;
+import java.util.Collections;
+import org.junit.Test;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import software.amazon.awssdk.services.ecs.ECSAsyncClient;
+
+@ContextConfiguration(classes = TestConfig.class)
+public class SchedulerEntrypointTest extends LambdaHandlerTestCase {
+
+  @Test
+  public void convertsInputsAndOutputsFromJson() throws Exception {
+    String result = callHandler(fixture("handlers/Scheduler.input.json"));
+    assertThat(result, is(fixtureAsString("handlers/Scheduler.output.json")));
+  }
+
+  @Configuration
+  @Import(SchedulerApplication.class)
+  public static class TestConfig {
+    @Bean
+    public ECSAsyncClient ecs() {
+      return mock(ECSAsyncClient.class);
+    }
+
+    @Bean
+    public SchedulerFactory schedulerFactory() {
+      return when(mock(SchedulerFactory.class).schedulerFor(any()))
+          .thenReturn((snapshot, deploymentConfiguration) -> Collections.emptyList())
+          .getMock();
+    }
+  }
+}

--- a/scheduling-manager/src/test/java/com/amazonaws/blox/scheduling/scheduler/SchedulerHandlerTest.java
+++ b/scheduling-manager/src/test/java/com/amazonaws/blox/scheduling/scheduler/SchedulerHandlerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.scheduling.scheduler;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.blox.dataservicemodel.v1.client.DataService;
+import com.amazonaws.blox.dataservicemodel.v1.model.DeploymentConfiguration;
+import com.amazonaws.blox.dataservicemodel.v1.model.DeploymentType;
+import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentVersion;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.DescribeTargetEnvironmentRevisionResponse;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.DescribeTargetEnvironmentRevisionRequest;
+import com.amazonaws.blox.scheduling.scheduler.engine.Scheduler;
+import com.amazonaws.blox.scheduling.scheduler.engine.SchedulerFactory;
+import com.amazonaws.blox.scheduling.scheduler.engine.SchedulingAction;
+import com.amazonaws.blox.scheduling.state.ClusterSnapshot;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.services.ecs.ECSAsyncClient;
+import software.amazon.awssdk.services.ecs.model.StartTaskResponse;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SchedulerHandlerTest {
+
+  private static final String CLUSTER_ARN = "arn:::::cluster1";
+  private static final String ENVIRONMENT_ARN = "arn:::::environment1";
+  private static final String TASK_DEFINITION = "arn:::::task:1";
+
+  @Mock private SchedulerFactory schedulerFactory;
+  @Mock private DataService dataService;
+  @Mock private ECSAsyncClient ecs;
+
+  @Test
+  public void invokesSchedulerCoreForDeploymentMethod() {
+    ClusterSnapshot snapshot =
+        new ClusterSnapshot(CLUSTER_ARN, Collections.emptyMap(), Collections.emptyMap());
+
+    EnvironmentVersion revision =
+        EnvironmentVersion.builder()
+            .environmentId(ENVIRONMENT_ARN)
+            .environmentVersion("v1")
+            .taskDefinition(TASK_DEFINITION)
+            .deploymentType(DeploymentType.SingleTask)
+            .deploymentConfiguration(DeploymentConfiguration.builder().build())
+            .build();
+
+    when(dataService.describeTargetEnvironmentRevision(
+            new DescribeTargetEnvironmentRevisionRequest(ENVIRONMENT_ARN)))
+        .thenReturn(new DescribeTargetEnvironmentRevisionResponse(revision));
+
+    SchedulingAction succesfulAction = e -> CompletableFuture.completedFuture(true);
+    SchedulingAction failedAction = e -> CompletableFuture.completedFuture(false);
+
+    Scheduler fakeScheduler = (s, environment) -> Arrays.asList(succesfulAction, failedAction);
+
+    when(schedulerFactory.schedulerFor(DeploymentType.SingleTask)).thenReturn(fakeScheduler);
+
+    StartTaskResponse successResponse = StartTaskResponse.builder().failures().build();
+
+    SchedulerHandler handler = new SchedulerHandler(dataService, ecs, schedulerFactory);
+    SchedulerOutput output =
+        handler.handleRequest(new SchedulerInput(snapshot, ENVIRONMENT_ARN), null);
+
+    assertThat(output.getSuccessfulActions(), is(1L));
+    assertThat(output.getFailedActions(), is(1L));
+  }
+}

--- a/scheduling-manager/src/test/resources/fixtures/handlers/Manager.input.json
+++ b/scheduling-manager/src/test/resources/fixtures/handlers/Manager.input.json
@@ -1,0 +1,1 @@
+{"clusterArn":"arn:aws:ecs:us-east-1:1234:cluster/default"}

--- a/scheduling-manager/src/test/resources/fixtures/handlers/Manager.output.json
+++ b/scheduling-manager/src/test/resources/fixtures/handlers/Manager.output.json
@@ -1,0 +1,1 @@
+{"clusterArn":"arn:aws:ecs:us-east-1:1234:cluster/default","scheduleResults":[{"clusterArn":"arn:aws:ecs:us-east-1:1234:cluster/default","environmentId":"SomeEnvironment","successfulActions":0,"failedActions":0}]}

--- a/scheduling-manager/src/test/resources/fixtures/handlers/Reconciler.input.json
+++ b/scheduling-manager/src/test/resources/fixtures/handlers/Reconciler.input.json
@@ -1,0 +1,13 @@
+{
+  "version": "0",
+  "id": "b502e063-441d-4ac6-9c51-24dda76a6b4d",
+  "detail-type": "Scheduled Event",
+  "source": "aws.events",
+  "account": "390815470484",
+  "time": "2017-10-03T21:13:14Z",
+  "region": "us-west-2",
+  "resources": [
+    "arn:aws:events:us-west-2:390815470484:rule/scheduling-manager-ReconcilerTrigger-ONCGS8O0D3X3"
+  ],
+  "detail": {}
+}

--- a/scheduling-manager/src/test/resources/fixtures/handlers/Scheduler.input.json
+++ b/scheduling-manager/src/test/resources/fixtures/handlers/Scheduler.input.json
@@ -1,0 +1,1 @@
+{"snapshot":{"clusterArn":"arn:aws:ecs:us-east-1:1234:cluster/default"},"environmentId":"arn:aws:ecs:us-east-1:1234:environment/SomeEnvironment"}

--- a/scheduling-manager/src/test/resources/fixtures/handlers/Scheduler.output.json
+++ b/scheduling-manager/src/test/resources/fixtures/handlers/Scheduler.output.json
@@ -1,0 +1,1 @@
+{"clusterArn":"arn:aws:ecs:us-east-1:1234:cluster/default","environmentId":"arn:aws:ecs:us-east-1:1234:environment/SomeEnvironment","successfulActions":0,"failedActions":0}

--- a/scheduling-manager/src/test/resources/log4j2-test.xml
+++ b/scheduling-manager/src/test/resources/log4j2-test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="trace">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/scheduling-manager/templates/scheduling_manager.yml
+++ b/scheduling-manager/templates/scheduling_manager.yml
@@ -1,6 +1,66 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Resources:
+  Scheduler:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: com.amazonaws.blox.scheduling.scheduler.SchedulerEntrypoint
+      Runtime: java8
+      CodeUri: ../build/distributions/scheduling-manager.zip
+      Timeout: 60
+      MemorySize: 512
+      Tracing: PassThrough
+      Policies:
+        - AWSXrayWriteOnlyAccess
+
+  Manager:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: com.amazonaws.blox.scheduling.manager.ManagerEntrypoint
+      Runtime: java8
+      CodeUri: ../build/distributions/scheduling-manager.zip
+      Timeout: 60
+      MemorySize: 512
+      Tracing: PassThrough
+      Policies:
+        - AWSLambdaFullAccess
+      Environment:
+        Variables:
+          scheduler_function_name: !Ref Scheduler
+
+  Reconciler:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: com.amazonaws.blox.scheduling.reconciler.ReconcilerEntrypoint
+      Runtime: java8
+      CodeUri: ../build/distributions/scheduling-manager.zip
+      Timeout: 60
+      MemorySize: 512
+      Tracing: Active
+      Policies:
+        - AWSLambdaFullAccess
+      Environment:
+        Variables:
+          manager_function_name: !Ref Manager
+
+  ReconcilerTrigger:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: Periodic trigger for Scheduler Reconciliation
+      ScheduleExpression: "rate(1 minute)"
+      Targets:
+        - Id: !Ref Reconciler
+          Arn:
+            Fn::GetAtt: [Reconciler, Arn]
+
+  ReconcilerPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref Reconciler
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn:
+        Fn::GetAtt: [ReconcilerTrigger, Arn]
 
   ProcessDeploymentRecords:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
This review adds the core Reconciler, Manager, and Scheduler lambda functions that comprise the Scheduling Manager, implementing #261.

- Reconciler: Reacts to periodic Cloudwatch events and kicks off a Manager instance for every cluster concurrently.
- Manager: Invoked per-cluster to retrieve a cluster state snapshot, and invoke a Scheduler instance for every Environment in that cluster.
- Scheduler: Invoked per-environment to make scheduling decisions (i.e. start/stop tasks)

A good place to get an overview of how this works, is in the `SchedulingSystemTest` test case. This wires up all the functions directly (without going through Lambda), and verifies that it starts a task.

In a production context, the functions  invoke each other through a `LambdaFunction<INPUT, OUTPUT>` interface, which has `*Async` methods that return `CompletableFuture` instance for fully concurrent operation. The concrete `AwsSdkV2LambdaFunction` implementation implements this interface with the new non-blocking Netty-based Lambda client, that allows us to reach 100s of concurrent invocations from a single lambda function.

In order to support more flexible serialization of the function inputs and outputs, this also implements a `JacksonRequestStreamHandler`, which allows us to customize the ObjectMapper to use for serializing/deserializing the input/output types. This would allow us to e.g. use Gzipped JSON or binary ION as the actual payload format between lambda functions.

The next steps not included in this review are:
- implement the actual ECSState interface to capture a cluster snapshot
- implement the actual DataService interface to get environment details