### PR TITLE
Add missing fields to FE model/mappers

### DIFF
--- a/frontend-service/src/main/java/com/amazonaws/blox/frontend/mappers/CreateEnvironmentMapper.java
+++ b/frontend-service/src/main/java/com/amazonaws/blox/frontend/mappers/CreateEnvironmentMapper.java
@@ -20,7 +20,7 @@ import com.amazonaws.serverless.proxy.internal.model.ApiGatewayRequestContext;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(uses = InstanceGroupMapper.class)
+@Mapper(uses = {InstanceGroupMapper.class, DeploymentConfigurationMapper.class})
 public interface CreateEnvironmentMapper {
   @Mapping(target = "environmentId.accountId", source = "context.accountId")
   @Mapping(target = "environmentId.cluster", source = "cluster")

--- a/frontend-service/src/main/java/com/amazonaws/blox/frontend/models/Environment.java
+++ b/frontend-service/src/main/java/com/amazonaws/blox/frontend/models/Environment.java
@@ -35,4 +35,5 @@ public final class Environment {
   private String deploymentMethod;
   private DeploymentConfiguration deploymentConfiguration;
   private String activeEnvironmentRevisionId;
+  private String latestEnvironmentRevisionId;
 }

--- a/frontend-service/src/test/java/com/amazonaws/blox/frontend/operations/CreateEnvironmentTest.java
+++ b/frontend-service/src/test/java/com/amazonaws/blox/frontend/operations/CreateEnvironmentTest.java
@@ -19,12 +19,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.amazonaws.blox.dataservicemodel.v1.model.DeploymentConfiguration;
 import com.amazonaws.blox.dataservicemodel.v1.model.Environment;
 import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentId;
 import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentRevision;
 import com.amazonaws.blox.dataservicemodel.v1.model.InstanceGroup;
 import com.amazonaws.blox.frontend.mappers.CreateEnvironmentMapper;
-import com.amazonaws.blox.frontend.models.DeploymentConfiguration;
 import com.amazonaws.blox.frontend.operations.CreateEnvironment.CreateEnvironmentRequest;
 import com.amazonaws.blox.frontend.operations.CreateEnvironment.CreateEnvironmentResponse;
 import java.time.Instant;
@@ -55,6 +55,7 @@ public class CreateEnvironmentTest extends EnvironmentControllerTestCase {
             .build();
 
     InstanceGroup instanceGroup = instanceGroupWithAttributeDS(ATTRIBUTE_NAME, ATTRIBUTE_VALUE);
+    DeploymentConfiguration deploymentConfiguration = deploymentConfigurationDS();
 
     when(dataService.createEnvironment(any()))
         .thenReturn(
@@ -68,14 +69,17 @@ public class CreateEnvironmentTest extends EnvironmentControllerTestCase {
                         .environmentHealth(HEALTHY)
                         .environmentStatus(STATUS)
                         .deploymentMethod(DEPLOYMENT_METHOD)
+                        .deploymentConfiguration(deploymentConfiguration)
                         .createdTime(Instant.now())
                         .lastUpdatedTime(Instant.now())
                         .build())
                 .environmentRevision(
                     EnvironmentRevision.builder()
+                        .environmentId(id)
                         .environmentRevisionId(ENVIRONMENT_REVISION_ID)
                         .instanceGroup(instanceGroup)
                         .taskDefinition(TASK_DEFINITION)
+                        .createdTime(Instant.now())
                         .build())
                 .build());
 
@@ -87,7 +91,7 @@ public class CreateEnvironmentTest extends EnvironmentControllerTestCase {
                 .environmentType(ENVIRONMENT_TYPE_STRING)
                 .role(ROLE)
                 .deploymentMethod(DEPLOYMENT_METHOD)
-                .deploymentConfiguration(DeploymentConfiguration.builder().build())
+                .deploymentConfiguration(deploymentConfigurationFE())
                 .instanceGroup(instanceGroupWithAttributeFE(ATTRIBUTE_NAME, ATTRIBUTE_VALUE))
                 .taskDefinition(TASK_DEFINITION)
                 .build());
@@ -97,6 +101,8 @@ public class CreateEnvironmentTest extends EnvironmentControllerTestCase {
             com.amazonaws.blox.dataservicemodel.v1.model.wrappers.CreateEnvironmentRequest.builder()
                 .environmentId(id)
                 .environmentType(ENVIRONMENT_TYPE)
+                .deploymentMethod(DEPLOYMENT_METHOD)
+                .deploymentConfiguration(deploymentConfiguration)
                 .instanceGroup(instanceGroup)
                 .role(ROLE)
                 .taskDefinition(TASK_DEFINITION)

--- a/frontend-service/src/test/java/com/amazonaws/blox/frontend/operations/DescribeEnvironmentRevisionTest.java
+++ b/frontend-service/src/test/java/com/amazonaws/blox/frontend/operations/DescribeEnvironmentRevisionTest.java
@@ -23,6 +23,7 @@ import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentId;
 import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentRevision;
 import com.amazonaws.blox.frontend.mappers.DescribeEnvironmentRevisionMapper;
 import com.amazonaws.blox.frontend.operations.DescribeEnvironmentRevision.DescribeEnvironmentRevisionResponse;
+import java.time.Instant;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,9 +52,11 @@ public class DescribeEnvironmentRevisionTest extends EnvironmentControllerTestCa
 
     EnvironmentRevision environmentRevision =
         EnvironmentRevision.builder()
+            .environmentId(id)
             .environmentRevisionId(ENVIRONMENT_REVISION_ID)
             .instanceGroup(instanceGroupWithAttributeDS(ATTRIBUTE_NAME, ATTRIBUTE_VALUE))
             .taskDefinition(TASK_DEFINITION)
+            .createdTime(Instant.now())
             .build();
 
     when(dataService.describeEnvironmentRevision(any()))

--- a/frontend-service/src/test/java/com/amazonaws/blox/frontend/operations/EnvironmentControllerTestCase.java
+++ b/frontend-service/src/test/java/com/amazonaws/blox/frontend/operations/EnvironmentControllerTestCase.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.mock;
 
 import com.amazonaws.blox.dataservicemodel.v1.client.DataService;
 import com.amazonaws.blox.dataservicemodel.v1.model.Attribute;
+import com.amazonaws.blox.dataservicemodel.v1.model.DeploymentConfiguration;
 import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentType;
 import com.amazonaws.blox.dataservicemodel.v1.model.InstanceGroup;
 import com.amazonaws.blox.frontend.MapperConfiguration;
@@ -54,6 +55,17 @@ public abstract class EnvironmentControllerTestCase {
   ApiGatewayRequestContext requestContext = new ApiGatewayRequestContext();
   DataService dataService = mock(DataService.class);
 
+  @Before
+  public void setupRequest() {
+    servletRequest = new MockHttpServletRequest();
+    servletRequest.setAttribute(
+        AwsProxyHttpServletRequestReader.API_GATEWAY_CONTEXT_PROPERTY, requestContext);
+  }
+
+  // TODO: Pull these helper methods out into a fixture generator class, so that we can do e.g:
+  // fixtures.DS.instanceGroup("key", "value");
+  // fixtures.FE.instanceGroup("key", "value");
+
   protected com.amazonaws.blox.frontend.models.InstanceGroup instanceGroupWithAttributeFE(
       String attributeName, String attributeValue) {
     return com.amazonaws.blox.frontend.models.InstanceGroup.builder()
@@ -77,10 +89,11 @@ public abstract class EnvironmentControllerTestCase {
         .build();
   }
 
-  @Before
-  public void setupRequest() {
-    servletRequest = new MockHttpServletRequest();
-    servletRequest.setAttribute(
-        AwsProxyHttpServletRequestReader.API_GATEWAY_CONTEXT_PROPERTY, requestContext);
+  protected DeploymentConfiguration deploymentConfigurationDS() {
+    return DeploymentConfiguration.builder().build();
+  }
+
+  protected com.amazonaws.blox.frontend.models.DeploymentConfiguration deploymentConfigurationFE() {
+    return com.amazonaws.blox.frontend.models.DeploymentConfiguration.builder().build();
   }
 }


### PR DESCRIPTION
Merging #308 after #314 without rebasing and retesting first introduced
some logical conflicts that caused the build to fail. Specifically, #314
introduced new mandatory fields on various data service model classes,
which weren't being set in the frontend service unit tests or mappers.

This adds those fields, which fixes the build.