### PR TITLE
Add delete environment DataService API

### DIFF
--- a/data-service/src/main/java/com/amazonaws/blox/dataservice/api/DataServiceApi.java
+++ b/data-service/src/main/java/com/amazonaws/blox/dataservice/api/DataServiceApi.java
@@ -54,6 +54,7 @@ public class DataServiceApi implements DataService {
   @NonNull private final ListEnvironmentsApi listEnvironmentsApi;
   @NonNull private final DescribeEnvironmentRevisionApi describeEnvironmentRevisionApi;
   @NonNull private final ListClustersApi listClustersApi;
+  @NonNull private final DeleteEnvironmentApi deleteEnvironmentApi;
 
   @Override
   public CreateEnvironmentResponse createEnvironment(
@@ -86,7 +87,7 @@ public class DataServiceApi implements DataService {
   public DeleteEnvironmentResponse deleteEnvironment(DeleteEnvironmentRequest request)
       throws ResourceNotFoundException, ResourceInUseException, InvalidParameterException,
           InternalServiceException {
-    return null;
+    return deleteEnvironmentApi.deleteEnvironment(request);
   }
 
   @Override

--- a/data-service/src/main/java/com/amazonaws/blox/dataservice/api/DeleteEnvironmentApi.java
+++ b/data-service/src/main/java/com/amazonaws/blox/dataservice/api/DeleteEnvironmentApi.java
@@ -42,6 +42,9 @@ public class DeleteEnvironmentApi {
     final EnvironmentId environmentId =
         apiModelMapper.toModelEnvironmentId(request.getEnvironmentId());
     try {
+      // Get the environment to check it exists
+      final Environment environment = environmentRepository.getEnvironment(environmentId);
+
       // List and delete all environment revisions
       final List<EnvironmentRevision> environmentRevisions =
           environmentRepository.listEnvironmentRevisions(environmentId);
@@ -51,8 +54,6 @@ public class DeleteEnvironmentApi {
         environmentRepository.deleteEnvironmentRevision(revision);
       }
 
-      // Get the environment to check it exist
-      final Environment environment = environmentRepository.getEnvironment(environmentId);
       // Delete the environment
       environmentRepository.deleteEnvironment(environmentId);
       return DeleteEnvironmentResponse.builder()

--- a/data-service/src/main/java/com/amazonaws/blox/dataservice/api/DeleteEnvironmentApi.java
+++ b/data-service/src/main/java/com/amazonaws/blox/dataservice/api/DeleteEnvironmentApi.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.dataservice.api;
+
+import com.amazonaws.blox.dataservice.mapper.ApiModelMapper;
+import com.amazonaws.blox.dataservice.model.Environment;
+import com.amazonaws.blox.dataservice.model.EnvironmentId;
+import com.amazonaws.blox.dataservice.model.EnvironmentRevision;
+import com.amazonaws.blox.dataservice.repository.EnvironmentRepository;
+import com.amazonaws.blox.dataservicemodel.v1.exception.InternalServiceException;
+import com.amazonaws.blox.dataservicemodel.v1.exception.ResourceNotFoundException;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.DeleteEnvironmentRequest;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.DeleteEnvironmentResponse;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@AllArgsConstructor
+public class DeleteEnvironmentApi {
+  @NonNull private final ApiModelMapper apiModelMapper;
+  @NonNull private final EnvironmentRepository environmentRepository;
+
+  // TODO: This deleteEnvironment is actually a reaper that removes the record from the dynamoDB tables. The actual deleteEnvironment should just update the status of the environment without removing the records
+  public DeleteEnvironmentResponse deleteEnvironment(@NonNull DeleteEnvironmentRequest request)
+      throws InternalServiceException, ResourceNotFoundException {
+    final EnvironmentId environmentId =
+        apiModelMapper.toModelEnvironmentId(request.getEnvironmentId());
+    try {
+      // List and delete all environment revisions
+      final List<EnvironmentRevision> environmentRevisions =
+          environmentRepository.listEnvironmentRevisions(environmentId);
+      // TODO: Need to stop all the running tasks from the scheduler manager
+
+      for (final EnvironmentRevision revision : environmentRevisions) {
+        environmentRepository.deleteEnvironmentRevision(revision);
+      }
+
+      // Get the environment to check it exist
+      final Environment environment = environmentRepository.getEnvironment(environmentId);
+      // Delete the environment
+      environmentRepository.deleteEnvironment(environmentId);
+      return DeleteEnvironmentResponse.builder()
+          .environment(apiModelMapper.toWrapperEnvironment(environment))
+          .build();
+    } catch (InternalServiceException | ResourceNotFoundException e) {
+      log.error(e.getMessage(), e);
+      throw e;
+    } catch (Exception e) {
+      log.error(e.getMessage(), e);
+      throw new InternalServiceException(e.getMessage(), e);
+    }
+  }
+}

--- a/data-service/src/main/java/com/amazonaws/blox/dataservice/repository/EnvironmentRepository.java
+++ b/data-service/src/main/java/com/amazonaws/blox/dataservice/repository/EnvironmentRepository.java
@@ -52,4 +52,6 @@ public interface EnvironmentRepository {
       throws InternalServiceException;
 
   List<Cluster> listClusters(String accountId, String clusterNamePrefix);
+
+  void deleteEnvironment(EnvironmentId environmentId) throws InternalServiceException;
 }

--- a/data-service/src/main/java/com/amazonaws/blox/dataservice/repository/EnvironmentRepositoryDDB.java
+++ b/data-service/src/main/java/com/amazonaws/blox/dataservice/repository/EnvironmentRepositoryDDB.java
@@ -416,4 +416,21 @@ public class EnvironmentRepositoryDDB implements EnvironmentRepository {
 
     return stream.collect(Collectors.toList());
   }
+
+  @Override
+  public void deleteEnvironment(@NonNull final EnvironmentId environmentId)
+      throws InternalServiceException {
+    try {
+      dynamoDBMapper.delete(
+          EnvironmentDDBRecord.withKeys(
+              environmentId.generateAccountIdCluster(), environmentId.getEnvironmentName()),
+          SaveBehavior.CLOBBER.config());
+    } catch (final AmazonServiceException e) {
+      throw new InternalServiceException(
+          String.format(
+              "Fail to delete environment with accountIdCluster %s and environment name %s",
+              environmentId.generateAccountIdCluster(), environmentId.getEnvironmentName()),
+          e);
+    }
+  }
 }

--- a/data-service/src/main/java/com/amazonaws/blox/dataservice/repository/EnvironmentRepositoryDDB.java
+++ b/data-service/src/main/java/com/amazonaws/blox/dataservice/repository/EnvironmentRepositoryDDB.java
@@ -423,8 +423,7 @@ public class EnvironmentRepositoryDDB implements EnvironmentRepository {
     try {
       dynamoDBMapper.delete(
           EnvironmentDDBRecord.withKeys(
-              environmentId.generateAccountIdCluster(), environmentId.getEnvironmentName()),
-          SaveBehavior.CLOBBER.config());
+              environmentId.generateAccountIdCluster(), environmentId.getEnvironmentName()));
     } catch (final AmazonServiceException e) {
       throw new InternalServiceException(
           String.format(

--- a/data-service/src/test/java/com/amazonaws/blox/dataservice/api/DeleteEnvironmentApiTest.java
+++ b/data-service/src/test/java/com/amazonaws/blox/dataservice/api/DeleteEnvironmentApiTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.dataservice.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.blox.dataservice.mapper.ApiModelMapper;
+import com.amazonaws.blox.dataservice.model.Environment;
+import com.amazonaws.blox.dataservice.model.EnvironmentId;
+import com.amazonaws.blox.dataservice.model.EnvironmentRevision;
+import com.amazonaws.blox.dataservice.repository.EnvironmentRepository;
+import com.amazonaws.blox.dataservicemodel.v1.exception.InternalServiceException;
+import com.amazonaws.blox.dataservicemodel.v1.exception.ResourceNotFoundException;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.DeleteEnvironmentRequest;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.DeleteEnvironmentResponse;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
+public class DeleteEnvironmentApiTest {
+
+  @Mock private EnvironmentRepository environmentRepository;
+  @Mock private ApiModelMapper apiModelMapper;
+  @Mock private EnvironmentId environmentId;
+  @Mock private com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentId wrapperEnvironmentId;
+  @Mock private Environment environment;
+  @Mock private com.amazonaws.blox.dataservicemodel.v1.model.Environment wrapperEnvironment;
+  @Mock private EnvironmentRevision environmentRevision;
+  @Mock private ResourceNotFoundException resourceNotFoundException;
+
+  private DeleteEnvironmentRequest deleteEnvironmentRequest;
+  private DeleteEnvironmentApi deleteEnvironmentApi;
+
+  @Before
+  public void setup() {
+    deleteEnvironmentApi = new DeleteEnvironmentApi(apiModelMapper, environmentRepository);
+    deleteEnvironmentRequest =
+        DeleteEnvironmentRequest.builder()
+            .environmentId(wrapperEnvironmentId)
+            .forceDelete(true)
+            .build();
+    when(apiModelMapper.toModelEnvironmentId(wrapperEnvironmentId)).thenReturn(environmentId);
+    when(apiModelMapper.toWrapperEnvironment(environment)).thenReturn(wrapperEnvironment);
+  }
+
+  @Test
+  public void testDeleteEnvironmentSuccess() throws Exception {
+    when(environmentRepository.listEnvironmentRevisions(environmentId))
+        .thenReturn(Collections.singletonList(environmentRevision));
+    doNothing().when(environmentRepository).deleteEnvironmentRevision(environmentRevision);
+    when(environmentRepository.getEnvironment(environmentId)).thenReturn(environment);
+    doNothing().when(environmentRepository).deleteEnvironment(environmentId);
+
+    final DeleteEnvironmentResponse deleteEnvironmentResponse =
+        deleteEnvironmentApi.deleteEnvironment(deleteEnvironmentRequest);
+    assertEquals(wrapperEnvironment, deleteEnvironmentResponse.getEnvironment());
+  }
+
+  @Test(expected = ResourceNotFoundException.class)
+  public void testDeleteEnvironmentResourceNotFoundException() throws Exception {
+    when(environmentRepository.listEnvironmentRevisions(environmentId))
+        .thenReturn(Collections.singletonList(environmentRevision));
+    doNothing().when(environmentRepository).deleteEnvironmentRevision(environmentRevision);
+    when(environmentRepository.getEnvironment(environmentId)).thenThrow(resourceNotFoundException);
+
+    deleteEnvironmentApi.deleteEnvironment(deleteEnvironmentRequest);
+  }
+
+  @Test(expected = InternalServiceException.class)
+  public void testDeleteEnvironmentInternalServiceException() throws Exception {
+    when(environmentRepository.listEnvironmentRevisions(environmentId))
+        .thenReturn(Collections.singletonList(environmentRevision));
+    doThrow(InternalServiceException.class)
+        .when(environmentRepository)
+        .deleteEnvironmentRevision(environmentRevision);
+
+    deleteEnvironmentApi.deleteEnvironment(deleteEnvironmentRequest);
+  }
+
+  @Test(expected = InternalServiceException.class)
+  public void testDeleteEnvironmentUnhandledException() throws Exception {
+    when(environmentRepository.listEnvironmentRevisions(environmentId))
+        .thenReturn(Collections.singletonList(environmentRevision));
+    doThrow(NullPointerException.class)
+        .when(environmentRepository)
+        .deleteEnvironmentRevision(environmentRevision);
+
+    deleteEnvironmentApi.deleteEnvironment(deleteEnvironmentRequest);
+  }
+}

--- a/data-service/src/test/java/com/amazonaws/blox/dataservice/api/DeleteEnvironmentApiTest.java
+++ b/data-service/src/test/java/com/amazonaws/blox/dataservice/api/DeleteEnvironmentApiTest.java
@@ -77,9 +77,6 @@ public class DeleteEnvironmentApiTest {
 
   @Test(expected = ResourceNotFoundException.class)
   public void testDeleteEnvironmentResourceNotFoundException() throws Exception {
-    when(environmentRepository.listEnvironmentRevisions(environmentId))
-        .thenReturn(Collections.singletonList(environmentRevision));
-    doNothing().when(environmentRepository).deleteEnvironmentRevision(environmentRevision);
     when(environmentRepository.getEnvironment(environmentId)).thenThrow(resourceNotFoundException);
 
     deleteEnvironmentApi.deleteEnvironment(deleteEnvironmentRequest);

--- a/data-service/src/test/java/com/amazonaws/blox/dataservice/repository/EnvironmentRepositoryDDBTest.java
+++ b/data-service/src/test/java/com/amazonaws/blox/dataservice/repository/EnvironmentRepositoryDDBTest.java
@@ -242,13 +242,10 @@ public class EnvironmentRepositoryDDBTest {
 
   @Test
   public void testDeleteEnvironmentSuccess() throws Exception {
-    doNothing()
-        .when(dynamoDBMapper)
-        .delete(any(EnvironmentDDBRecord.class), any(DynamoDBMapperConfig.class));
+    doNothing().when(dynamoDBMapper).delete(any(EnvironmentDDBRecord.class));
 
     environmentRepositoryDDB.deleteEnvironment(environmentId);
-    verify(dynamoDBMapper, times(1))
-        .delete(environmentDDBRecordArgumentCaptor.capture(), eq(CONFIG));
+    verify(dynamoDBMapper, times(1)).delete(environmentDDBRecordArgumentCaptor.capture());
     assertEquals(
         environmentId.generateAccountIdCluster(),
         environmentDDBRecordArgumentCaptor.getValue().getAccountIdCluster());
@@ -261,7 +258,7 @@ public class EnvironmentRepositoryDDBTest {
   public void testDeleteEnvironmentInternalError() throws Exception {
     doThrow(AmazonServiceException.class)
         .when(dynamoDBMapper)
-        .delete(any(EnvironmentDDBRecord.class), any(DynamoDBMapperConfig.class));
+        .delete(any(EnvironmentDDBRecord.class));
 
     thrown.expect(InternalServiceException.class);
     thrown.expectMessage(

--- a/data-service/src/test/java/com/amazonaws/blox/dataservice/repository/EnvironmentRepositoryDDBTest.java
+++ b/data-service/src/test/java/com/amazonaws/blox/dataservice/repository/EnvironmentRepositoryDDBTest.java
@@ -16,9 +16,13 @@ package com.amazonaws.blox.dataservice.repository;
 
 import static com.amazonaws.blox.dataservice.repository.model.EnvironmentDDBRecord.ENVIRONMENT_NAME_RANGE_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -34,6 +38,7 @@ import com.amazonaws.blox.dataservice.repository.model.EnvironmentRevisionDDBRec
 import com.amazonaws.blox.dataservicemodel.v1.exception.InternalServiceException;
 import com.amazonaws.blox.dataservicemodel.v1.exception.ResourceNotFoundException;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
 import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
@@ -59,6 +64,8 @@ public class EnvironmentRepositoryDDBTest {
   private static final String CLUSTER = "mycluster";
   private static final String ENVIRONMENT_NAME = "myenv";
   private static final String ENVIRONMENT_REVISION_ID = "revision-id";
+  private static final DynamoDBMapperConfig CONFIG =
+      DynamoDBMapperConfig.SaveBehavior.CLOBBER.config();
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 
@@ -73,6 +80,7 @@ public class EnvironmentRepositoryDDBTest {
   @InjectMocks private EnvironmentRepositoryDDB environmentRepositoryDDB;
 
   @Captor private ArgumentCaptor<DynamoDBQueryExpression> ddbQueryExpressionCaptor;
+  @Captor private ArgumentCaptor<EnvironmentDDBRecord> environmentDDBRecordArgumentCaptor;
 
   private EnvironmentId environmentId;
   private Cluster cluster;
@@ -230,5 +238,35 @@ public class EnvironmentRepositoryDDBTest {
         String.format("Could not query environments for cluster %s", cluster.toString()));
 
     environmentRepositoryDDB.listEnvironments(cluster, null);
+  }
+
+  @Test
+  public void testDeleteEnvironmentSuccess() throws Exception {
+    doNothing()
+        .when(dynamoDBMapper)
+        .delete(any(EnvironmentDDBRecord.class), any(DynamoDBMapperConfig.class));
+
+    environmentRepositoryDDB.deleteEnvironment(environmentId);
+    verify(dynamoDBMapper, times(1))
+        .delete(environmentDDBRecordArgumentCaptor.capture(), eq(CONFIG));
+    assertEquals(
+        environmentId.generateAccountIdCluster(),
+        environmentDDBRecordArgumentCaptor.getValue().getAccountIdCluster());
+    assertEquals(
+        environmentId.getEnvironmentName(),
+        environmentDDBRecordArgumentCaptor.getValue().getEnvironmentName());
+  }
+
+  @Test
+  public void testDeleteEnvironmentInternalError() throws Exception {
+    doThrow(AmazonServiceException.class)
+        .when(dynamoDBMapper)
+        .delete(any(EnvironmentDDBRecord.class), any(DynamoDBMapperConfig.class));
+
+    thrown.expect(InternalServiceException.class);
+    thrown.expectMessage(
+        "Fail to delete environment with accountIdCluster 123456789012/mycluster and environment name myenv");
+
+    environmentRepositoryDDB.deleteEnvironment(environmentId);
   }
 }


### PR DESCRIPTION
#### Summary
This PR implements the DeleteEnvironemntApi for data service. 
As agreed with the team, this Api currently does the job of a reaper, which deletes the actual record of Environment/EnvironmentRevision from the DDB.

#### Implementation details
<!-- How are the changes implemented? -->

#### Testing
./gradlew check
./gradlew clean build

New tests cover the changes: <!-- yes|no -->

#### Description for the changelog
<!--
Write a short summary that describes the changes in this pull request
for inclusion in changelog.
-->

#### Licensing

This contribution is under the terms of the Apache 2.0 License: Yes

#### Before merging
<!-- Run integration and end-to-end tests before merging -->
