### PR TITLE
Fix errors in describe environment cucumber tests

### DIFF
--- a/integ-tests/src/cucumberTest/java/cucumber/steps/dataservice/DataServiceSteps.java
+++ b/integ-tests/src/cucumberTest/java/cucumber/steps/dataservice/DataServiceSteps.java
@@ -114,8 +114,7 @@ public class DataServiceSteps implements En {
         () -> {
           final EnvironmentId environmentId = getEnvironmentIdFromCreatedEnvironment();
           dataServiceWrapper.describeEnvironment(
-              inputCreator.describeEnvironmentRequest(
-                  environmentId.getEnvironmentName(), environmentId.getCluster()));
+              inputCreator.describeEnvironmentRequest(environmentId));
         });
 
     When(
@@ -123,8 +122,7 @@ public class DataServiceSteps implements En {
         () -> {
           final EnvironmentId environmentId = getEnvironmentIdFromUpdatedEnvironment();
           dataServiceWrapper.describeEnvironment(
-              inputCreator.describeEnvironmentRequest(
-                  environmentId.getEnvironmentName(), environmentId.getCluster()));
+              inputCreator.describeEnvironmentRequest(environmentId));
         });
 
     Then(
@@ -172,8 +170,7 @@ public class DataServiceSteps implements En {
         () -> {
           final EnvironmentId environmentId = getEnvironmentIdFromCreatedEnvironment();
           dataServiceWrapper.deleteEnvironment(
-              inputCreator.deleteEnvironmentRequest(
-                  environmentId.getEnvironmentName(), environmentId.getCluster()));
+              inputCreator.deleteEnvironmentRequest(environmentId));
         });
 
     When(
@@ -181,8 +178,7 @@ public class DataServiceSteps implements En {
         () -> {
           final EnvironmentId environmentId = getEnvironmentIdFromCreatedEnvironment();
           dataServiceWrapper.tryDescribeEnvironment(
-              inputCreator.describeEnvironmentRequest(
-                  environmentId.getEnvironmentName(), environmentId.getCluster()));
+              inputCreator.describeEnvironmentRequest(environmentId));
         });
 
     Then(

--- a/integ-tests/src/cucumberTest/java/cucumber/steps/helpers/InputCreator.java
+++ b/integ-tests/src/cucumberTest/java/cucumber/steps/helpers/InputCreator.java
@@ -84,13 +84,13 @@ public class InputCreator {
         .build();
   }
 
-  public DescribeEnvironmentRequest describeEnvironmentRequest(
+  private DescribeEnvironmentRequest describeEnvironmentRequest(
       final String environmentName, final String cluster) {
     EnvironmentId id = environmentId(environmentName, cluster);
     return describeEnvironmentRequest(id);
   }
 
-  private DescribeEnvironmentRequest describeEnvironmentRequest(final EnvironmentId id) {
+  public DescribeEnvironmentRequest describeEnvironmentRequest(final EnvironmentId id) {
     return DescribeEnvironmentRequest.builder().environmentId(id).build();
   }
 
@@ -106,6 +106,13 @@ public class InputCreator {
         .role(getRoleArn())
         .taskDefinition(getTaskDefinitionArn())
         .instanceGroup(InstanceGroup.builder().attributes(Collections.emptySet()).build())
+        .build();
+  }
+
+  public DeleteEnvironmentRequest deleteEnvironmentRequest(final EnvironmentId environmentId) {
+    return DeleteEnvironmentRequest.builder()
+        .environmentId(environmentId)
+        .forceDelete(false)
         .build();
   }
 

--- a/integ-tests/src/cucumberTest/resources/features/dataservice/describe_environment.feature
+++ b/integ-tests/src/cucumberTest/resources/features/dataservice/describe_environment.feature
@@ -1,4 +1,3 @@
-@ignore
 @dataservice
 @describe-environment
 Feature: Describe environment


### PR DESCRIPTION
#### Summary
Fix some errors in DescribeEnvironment cucumber test, so it accepts the correct environmentId. 

The test still fails for the exception messages (because of the JSON RPC problem), and for the case that requires an update environment, given that we haven't implemented update yet. 

#### Implementation details
<!-- How are the changes implemented? -->

#### Testing
./gradlew clean build
./gradlew cucumberTest

New tests cover the changes: <!-- yes|no -->

#### Description for the changelog
<!--
Write a short summary that describes the changes in this pull request
for inclusion in changelog.
-->

#### Licensing

This contribution is under the terms of the Apache 2.0 License: Yes

#### Before merging
<!-- Run integration and end-to-end tests before merging -->
