### PR TITLE
Add client and server side error/exception resolvers that support POJOs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ subprojects {
             }
             dependencySet(group: 'org.slf4j', version: '1.7.+') {
                 entry 'slf4j-api'
+                entry 'slf4j-simple'
                 entry 'jcl-over-slf4j'
             }
             dependencySet(group: 'org.mapstruct', version: '1.2.0.CR2') {

--- a/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/exception/ResourceExistsException.java
+++ b/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/exception/ResourceExistsException.java
@@ -14,6 +14,8 @@
  */
 package com.amazonaws.blox.dataservicemodel.v1.exception;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 @Getter
@@ -22,7 +24,10 @@ public class ResourceExistsException extends ClientException {
   private String resourceType;
   private String resourceId;
 
-  public ResourceExistsException(String resourceType, String resourceId) {
+  @JsonCreator
+  public ResourceExistsException(
+      @JsonProperty("resourceType") String resourceType,
+      @JsonProperty("resourceId") String resourceId) {
     super(String.format("%s with id %s already exists", resourceType, resourceId));
 
     this.resourceType = resourceType;

--- a/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/exception/ResourceInUseException.java
+++ b/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/exception/ResourceInUseException.java
@@ -14,6 +14,8 @@
  */
 package com.amazonaws.blox.dataservicemodel.v1.exception;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 @Getter
@@ -22,7 +24,11 @@ public class ResourceInUseException extends ClientException {
   private String resourceType;
   private String resourceId;
 
-  public ResourceInUseException(String resourceType, String resourceId, String message) {
+  @JsonCreator
+  public ResourceInUseException(
+      @JsonProperty("resourceType") String resourceType,
+      @JsonProperty("resourceId") String resourceId,
+      @JsonProperty("message") String message) {
     super(message);
 
     this.resourceType = resourceType;

--- a/integ-tests/build.gradle
+++ b/integ-tests/build.gradle
@@ -17,6 +17,11 @@ cucumberTest {
     systemProperties = [
             'aws.region': stack.region.toString(),
             'aws.defaultProfile': stack.profile.toString(),
+
+            // Suppress the Spring Context's verbose startup logs that usualy get
+            // emitted on each scenario run, but still warn when things go wrong.
+            // If you want to debug Spring issues, set this to info or debug.
+            'org.slf4j.simpleLogger.log.org.springframework': 'warn',
     ]
 }
 
@@ -27,7 +32,12 @@ dependencies {
         'com.google.guava:guava:23.0',
         'info.cukes:cucumber-java8:1.2.5',
         'info.cukes:cucumber-spring:1.2.5',
-        // To use JUnit assertions in the step definitions:
+
+        // Wire the Spring Framework's JCL logs into SLF4J
+        'org.slf4j:jcl-over-slf4j',
+        // Use the SLF4J simpleLogger for logging in tests
+        'org.slf4j:slf4j-simple',
+
         'junit:junit:4.12',
         'org.assertj:assertj-core:3.8+',
 

--- a/integ-tests/src/cucumberTest/java/cucumber/steps/dataservice/DataServiceSteps.java
+++ b/integ-tests/src/cucumberTest/java/cucumber/steps/dataservice/DataServiceSteps.java
@@ -19,9 +19,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.amazonaws.blox.dataservicemodel.v1.exception.ResourceExistsException;
-import com.amazonaws.blox.dataservicemodel.v1.exception.ResourceInUseException;
-import com.amazonaws.blox.dataservicemodel.v1.exception.ResourceNotFoundException;
 import com.amazonaws.blox.dataservicemodel.v1.model.Cluster;
 import com.amazonaws.blox.dataservicemodel.v1.model.Environment;
 import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentHealth;
@@ -194,46 +191,24 @@ public class DataServiceSteps implements En {
     Then(
         "^there should be an? \"?\'?(\\w*)\"?\'? thrown$",
         (final String exceptionName) -> {
-          assertNotNull("Expecting an exception to be thrown", exceptionContext.getException());
-          assertEquals(exceptionName, exceptionContext.getException().getClass().getSimpleName());
+          assertThat(exceptionContext.getException())
+              .isNotNull()
+              .satisfies(t -> assertThat(t.getClass().getSimpleName()).isEqualTo(exceptionName));
         });
 
     And(
-        "^the resourceType is \"([^\"]*)\"$",
-        (final String resourceType) -> {
-          assertNotNull("Expecting an exception to be thrown", exceptionContext.getException());
-          if (exceptionContext.getException() instanceof ResourceNotFoundException) {
-            final ResourceNotFoundException exception =
-                (ResourceNotFoundException) exceptionContext.getException();
-            assertEquals(resourceType, exception.getResourceType());
-          } else if (exceptionContext.getException() instanceof ResourceExistsException) {
-            final ResourceExistsException exception =
-                (ResourceExistsException) exceptionContext.getException();
-            assertEquals(resourceType, exception.getResourceType());
-          } else if (exceptionContext.getException() instanceof ResourceInUseException) {
-            final ResourceInUseException exception =
-                (ResourceInUseException) exceptionContext.getException();
-            assertEquals(resourceType, exception.getResourceType());
-          }
+        "^its ([^ ]*) is \"([^\"]*)\"$",
+        (final String field, final String value) -> {
+          assertThat(exceptionContext.getException()).hasFieldOrPropertyWithValue(field, value);
         });
 
     And(
-        "^the resourceId contains \"([^\"]*)\"$",
-        (final String resourceId) -> {
-          assertNotNull("Expecting an exception to be thrown", exceptionContext.getException());
-          if (exceptionContext.getException() instanceof ResourceNotFoundException) {
-            final ResourceNotFoundException exception =
-                (ResourceNotFoundException) exceptionContext.getException();
-            assertEquals(resourceId, exception.getResourceType());
-          } else if (exceptionContext.getException() instanceof ResourceExistsException) {
-            final ResourceExistsException exception =
-                (ResourceExistsException) exceptionContext.getException();
-            assertEquals(resourceId, exception.getResourceType());
-          } else if (exceptionContext.getException() instanceof ResourceInUseException) {
-            final ResourceInUseException exception =
-                (ResourceInUseException) exceptionContext.getException();
-            assertEquals(resourceId, exception.getResourceType());
-          }
+        "^its ([^ ]*) contains \"([^\"]*)\"$",
+        (final String field, final String value) -> {
+          assertThat(exceptionContext.getException())
+              .hasFieldOrProperty(field)
+              .extracting(field)
+              .allSatisfy(s -> assertThat(s).asString().contains(value));
         });
 
     When(

--- a/integ-tests/src/cucumberTest/java/cucumber/steps/helpers/ThrowingFunction.java
+++ b/integ-tests/src/cucumberTest/java/cucumber/steps/helpers/ThrowingFunction.java
@@ -15,17 +15,15 @@
 package cucumber.steps.helpers;
 
 import java.util.function.Function;
+import lombok.SneakyThrows;
 
 @FunctionalInterface
 public interface ThrowingFunction<T, R> extends Function<T, R> {
 
   @Override
+  @SneakyThrows
   default R apply(T t) {
-    try {
-      return applyThrows(t);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+    return applyThrows(t);
   }
 
   R applyThrows(T t) throws Exception;

--- a/integ-tests/src/cucumberTest/java/cucumber/steps/wrappers/MemoizedWrapper.java
+++ b/integ-tests/src/cucumberTest/java/cucumber/steps/wrappers/MemoizedWrapper.java
@@ -27,7 +27,8 @@ public class MemoizedWrapper implements Memoized {
       Multimaps.synchronizedListMultimap(ArrayListMultimap.create());
 
   @Override
-  public <T> T getLastFromHistory(Class<T> type) {
+  @SuppressWarnings("unchecked")
+  public <T> T getLastFromHistory(final Class<T> type) {
     return (T) memory.get(type).get(memory.get(type).size() - 1);
   }
 
@@ -37,6 +38,7 @@ public class MemoizedWrapper implements Memoized {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public final <T, R> R memoizeFunction(final T input, final ThrowingFunction<T, R> fn) {
     Validate.notNull(input);
 

--- a/integ-tests/src/cucumberTest/resources/features/dataservice/create_environment.feature
+++ b/integ-tests/src/cucumberTest/resources/features/dataservice/create_environment.feature
@@ -6,13 +6,12 @@ Feature: Create environment
     When I create an environment
     Then the created environment response is valid
 
-  @ignore
   Scenario: Create an environment that already exists
     Given I create an environment named "test" in the cluster "testCluster"
     When I try to create another environment with the name "test" in the cluster "testCluster"
     Then there should be a ResourceExistsException thrown
-    And the resourceType is "environment"
-    And the resourceId contains "test"
+    And its resourceType is "environment"
+    And its resourceId contains "test"
 
   Scenario: Create an environment that has the same name as another environment in a different cluster
     Given I create an environment named "test"

--- a/integ-tests/src/cucumberTest/resources/features/dataservice/describe_environment.feature
+++ b/integ-tests/src/cucumberTest/resources/features/dataservice/describe_environment.feature
@@ -14,12 +14,11 @@ Feature: Describe environment
     When I describe the updated environment
     Then the updated and described environments match
 
-  @ignore
   Scenario: Describe a non-existent environment
     When I try to describe a non-existent environment named "non-existent"
     Then there should be a ResourceNotFoundException thrown
-    And the resourceType is "environment"
-    And the resourceId contains "non-existent"
+    And its resourceType is "environment"
+    And its resourceId contains "non-existent"
 
   @ignore
   Scenario: Describe a deleted environment
@@ -27,7 +26,7 @@ Feature: Describe environment
     And I delete the created environment
     When I try to describe the created environment
     Then there should be a ResourceNotFoundException thrown
-    And the resourceType is "environment"
-    And the resourceId contains "test"
+    And its resourceType is "environment"
+    And its resourceId contains "test"
 
   #TODO: Add invalid parameter tests

--- a/json-rpc-core/build.gradle
+++ b/json-rpc-core/build.gradle
@@ -8,15 +8,11 @@ version '0.1-SNAPSHOT'
 sourceCompatibility = 1.8
 
 dependencies {
-    compile project(":json-rpc-core")
-
-    compile 'com.amazonaws:aws-lambda-java-core:1.+'
+    compile "com.github.briandilley.jsonrpc4j:jsonrpc4j:+"
+    compile "org.projectlombok:lombok"
 
     testCompile "org.slf4j:slf4j-simple"
-    testCompile project(":json-rpc-lambda-client")
     testCompile "junit:junit:4.12"
-    testCompile "org.mockito:mockito-core"
     testCompile "org.assertj:assertj-core:3.8+"
-
     testCompileOnly "org.projectlombok:lombok"
 }

--- a/json-rpc-core/src/main/java/com/amazonaws/blox/jsonrpc/PojoErrorResolver.java
+++ b/json-rpc-core/src/main/java/com/amazonaws/blox/jsonrpc/PojoErrorResolver.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.jsonrpc;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.googlecode.jsonrpc4j.ErrorResolver;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class PojoErrorResolver implements ErrorResolver {
+  // Since we encode the type name, just use one error code for all errors that were encoded by this
+  // resolver. The number is arbitrary, and just chosen to be high enough to not accidentally
+  // conflict with another error code.
+  public static final int ERROR_CODE = 9001;
+
+  private final ObjectMapper mapper;
+
+  public PojoErrorResolver(final ObjectMapper mapper) {
+    this.mapper = mapper.copy().addMixIn(Throwable.class, ThrowableSerializationMixin.class);
+  }
+
+  @Override
+  public JsonError resolveError(
+      final Throwable t, final Method method, final List<JsonNode> arguments) {
+
+    final boolean isModeledException =
+        Arrays.stream(method.getExceptionTypes()).anyMatch(aClass -> aClass.isInstance(t));
+
+    if (isModeledException) {
+      // We have to explicitly serialize the exception type here using the mapper, rather than
+      // relying on the mapper serializing the entire JsonError object. This is needed because
+      // Jackson looks up the mixins based on the type of the *variable* not the object instance.
+      // Since the type of the data field on JsonError is just Object, it then doesn't correctly
+      // apply the annotations from ThrowableSerializationMixin.
+      final JsonNode node = mapper.valueToTree(t);
+      return new JsonError(ERROR_CODE, t.getMessage(), node);
+    }
+
+    log.warn(
+        "Exception type {} is not modeled in signature of {}, returning generic error",
+        t.getClass(),
+        method.getName());
+
+    return new JsonError(JsonError.INTERNAL_ERROR.code, t.getMessage(), null);
+  }
+}

--- a/json-rpc-core/src/main/java/com/amazonaws/blox/jsonrpc/PojoExceptionResolver.java
+++ b/json-rpc-core/src/main/java/com/amazonaws/blox/jsonrpc/PojoExceptionResolver.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.jsonrpc;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.googlecode.jsonrpc4j.ExceptionResolver;
+import com.googlecode.jsonrpc4j.JsonRpcBasicServer;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class PojoExceptionResolver implements ExceptionResolver {
+  private final ObjectMapper mapper;
+
+  public PojoExceptionResolver(final ObjectMapper mapper) {
+    this.mapper = mapper.copy().addMixIn(Throwable.class, ThrowableSerializationMixin.class);
+  }
+
+  /**
+   * Resolves a given JSON-RPC error response into a Throwable.
+   *
+   * <p>Callers expect this method to return null (instead of raising an exception) if it cannot
+   * deserialize the given response object.
+   */
+  @Override
+  public Throwable resolveException(final ObjectNode response) {
+    log.trace("Resolving exception from JSON response {}", response);
+
+    final JsonNode error = response.get(JsonRpcBasicServer.ERROR);
+    if (error == null || !error.isObject()) {
+      log.warn("No error information found in JSON response {}", response);
+      return null;
+    }
+
+    final JsonNode code = error.get(JsonRpcBasicServer.ERROR_CODE);
+    if (code == null || !code.isInt() || code.asInt() != ThrowableSerializationMixin.ERROR_CODE) {
+      log.warn("Not resolving exception for unsupported error code {}", code);
+      return null;
+    }
+
+    final JsonNode data = error.get(JsonRpcBasicServer.DATA);
+    if (data == null || !data.isObject()) {
+      log.warn("No error details included in data field of JSON error {}", error);
+      return null;
+    }
+
+    final ObjectNode dataObject = ((ObjectNode) data);
+    if (!dataObject.has(JsonRpcBasicServer.ERROR_MESSAGE)) {
+      dataObject.set(
+          JsonRpcBasicServer.ERROR_MESSAGE,
+          new TextNode(error.get(JsonRpcBasicServer.ERROR_MESSAGE).asText()));
+    }
+
+    try {
+      return mapper.treeToValue(data, Throwable.class);
+    } catch (final JsonProcessingException e) {
+      log.warn("Unable to convert JSON response error '{}' into Throwable", data, e);
+      return null;
+    }
+  }
+}

--- a/json-rpc-core/src/main/java/com/amazonaws/blox/jsonrpc/ThrowableSerializationMixin.java
+++ b/json-rpc-core/src/main/java/com/amazonaws/blox/jsonrpc/ThrowableSerializationMixin.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.jsonrpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.googlecode.jsonrpc4j.JsonRpcBasicServer;
+
+/**
+ * Jackson Mixin to control serialization of Throwables in error responses.
+ *
+ * <p>It suppress detailed fields of exceptions being serialized in JSON-RPC error responses, and
+ * adds a property to the the serialized JSON that contains the Java class name of the exception, so
+ * that the client can deserialize the correct exception class.
+ */
+@JsonIgnoreProperties(value = {"stackTrace", "suppressed", "cause", "localisedMessage"})
+@JsonTypeInfo(
+  use = Id.CLASS,
+  include = As.PROPERTY,
+  property = JsonRpcBasicServer.EXCEPTION_TYPE_NAME
+)
+interface ThrowableSerializationMixin {
+  int ERROR_CODE = 9001;
+}

--- a/json-rpc-core/src/test/java/com/amazonaws/blox/jsonrpc/PojoErrorResolverTest.java
+++ b/json-rpc-core/src/test/java/com/amazonaws/blox/jsonrpc/PojoErrorResolverTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.jsonrpc;
+
+import static com.amazonaws.blox.test.JsonNodeAssert.assertThat;
+
+import com.amazonaws.blox.jsonrpc.fixtures.PojoService;
+import com.amazonaws.blox.jsonrpc.fixtures.PojoTestException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.googlecode.jsonrpc4j.ErrorResolver.JsonError;
+import com.googlecode.jsonrpc4j.JsonRpcBasicServer;
+import java.util.Arrays;
+import org.junit.Test;
+
+public class PojoErrorResolverTest {
+  private ObjectMapper mapper = new ObjectMapper();
+  private PojoErrorResolver resolver = new PojoErrorResolver(mapper);
+
+  @Test
+  public void itPreservesErrorInformationForModeledExceptions() throws Exception {
+    PojoTestException e =
+        new PojoTestException("some value", "another value", new RuntimeException("oh dear!"));
+
+    JsonError error =
+        resolver.resolveError(
+            e,
+            PojoService.class.getMethod("pojoCall", String.class),
+            Arrays.asList(new TextNode("foo")));
+
+    JsonNode node = mapper.valueToTree(error);
+
+    assertThat(node)
+        .hasField("code", PojoErrorResolver.ERROR_CODE)
+        .hasField("message", "some value:another value");
+
+    JsonNode data = node.get("data");
+
+    assertThat(data)
+        .hasField(JsonRpcBasicServer.EXCEPTION_TYPE_NAME, PojoTestException.class.getName())
+        .hasField("someValue", "some value")
+        .hasField("anotherValue", "another value")
+        .hasNoField("cause")
+        .hasNoField("stackTrace")
+        .hasNoField("suppressed")
+        .hasNoField("localisedMessage");
+  }
+
+  @Test
+  public void itReturnsGenericErrorForUnmodeledExceptions() throws Exception {
+    PojoTestException e =
+        new PojoTestException("some value", "another value", new RuntimeException("oh dear!"));
+
+    JsonError error =
+        resolver.resolveError(
+            e,
+            PojoService.class.getMethod("nonPojoCall", String.class),
+            Arrays.asList(new TextNode("foo")));
+
+    JsonNode node = mapper.valueToTree(error);
+
+    assertThat(node)
+        .hasField("code", JsonError.INTERNAL_ERROR.code)
+        .hasField("message", "some value:another value")
+        .hasNullField("data");
+  }
+}

--- a/json-rpc-core/src/test/java/com/amazonaws/blox/jsonrpc/PojoExceptionResolverTest.java
+++ b/json-rpc-core/src/test/java/com/amazonaws/blox/jsonrpc/PojoExceptionResolverTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.jsonrpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.amazonaws.blox.jsonrpc.fixtures.PojoTestException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.googlecode.jsonrpc4j.JsonRpcBasicServer;
+import org.junit.Test;
+
+public class PojoExceptionResolverTest {
+
+  private static final Integer RANDOM_ERROR_CODE = 123456;
+  private static final String VALID_MESSAGE = "Something went horribly wrong.";
+  private static final String OTHER_MESSAGE = "Something completely different went horribly wrong.";
+  private ObjectMapper mapper = new ObjectMapper();
+
+  private PojoExceptionResolver resolver = new PojoExceptionResolver(mapper);
+
+  @Test
+  public void itDeserializesPojoExceptionsWithJsonCreatorConstructor() {
+    ObjectNode response =
+        response(
+            error(
+                ThrowableSerializationMixin.ERROR_CODE,
+                VALID_MESSAGE,
+                data(PojoTestException.class.getTypeName(), "someValue=foo", "anotherValue=bar")));
+
+    Throwable throwable = resolver.resolveException(response);
+
+    assertThat(throwable)
+        .isInstanceOf(PojoTestException.class)
+        .hasMessage("foo:bar")
+        .hasFieldOrPropertyWithValue("someValue", "foo")
+        .hasFieldOrPropertyWithValue("anotherValue", "bar");
+  }
+
+  @Test
+  public void itReturnsNullForNonErrorResponse() {
+    ObjectNode response = response(null);
+
+    Throwable throwable = resolver.resolveException(response);
+
+    assertThat(throwable).isNull();
+  }
+
+  @Test
+  public void itReturnsNullForOtherErrorCodes() {
+    ObjectNode response =
+        response(
+            error(RANDOM_ERROR_CODE, VALID_MESSAGE, data(PojoTestException.class.getTypeName())));
+
+    Throwable throwable = resolver.resolveException(response);
+
+    assertThat(throwable).isNull();
+  }
+
+  @Test
+  public void itReturnsNullForErrorsWithMissingData() {
+    ObjectNode response =
+        response(error(ThrowableSerializationMixin.ERROR_CODE, VALID_MESSAGE, null));
+
+    Throwable throwable = resolver.resolveException(response);
+
+    assertThat(throwable).isNull();
+  }
+
+  @Test
+  public void itReturnsNullWhenJacksonDeserializationFails() {
+    ObjectNode response =
+        response(
+            error(
+                ThrowableSerializationMixin.ERROR_CODE,
+                VALID_MESSAGE,
+                data(PojoTestException.class.getTypeName(), "invalidProperty=badValue")));
+
+    Throwable throwable = resolver.resolveException(response);
+
+    assertThat(throwable).isNull();
+  }
+
+  @Test
+  public void itDeserializesExceptionsWithOnlyMessageConstructor() {
+    ObjectNode response =
+        response(
+            error(
+                ThrowableSerializationMixin.ERROR_CODE,
+                VALID_MESSAGE,
+                data(RuntimeException.class.getTypeName())));
+
+    Throwable throwable = resolver.resolveException(response);
+
+    assertThat(throwable).isInstanceOf(RuntimeException.class).hasMessage(VALID_MESSAGE);
+  }
+
+  @Test
+  public void itPrefersMessageFromDataOverMessageFromError() {
+    ObjectNode response =
+        response(
+            error(
+                ThrowableSerializationMixin.ERROR_CODE,
+                VALID_MESSAGE,
+                data(RuntimeException.class.getTypeName(), "message=" + OTHER_MESSAGE)));
+
+    Throwable throwable = resolver.resolveException(response);
+
+    assertThat(throwable).isInstanceOf(RuntimeException.class).hasMessage(OTHER_MESSAGE);
+  }
+
+  private ObjectNode response(ObjectNode error) {
+    ObjectNode response = mapper.createObjectNode();
+    response.set(JsonRpcBasicServer.ERROR, error);
+
+    return response;
+  }
+
+  private ObjectNode error(Integer code, String message, ObjectNode data) {
+    ObjectNode error = mapper.createObjectNode();
+    if (code != null) error.set(JsonRpcBasicServer.ERROR_CODE, new IntNode(code));
+    if (message != null) error.set(JsonRpcBasicServer.ERROR_MESSAGE, new TextNode(message));
+    if (data != null) error.set(JsonRpcBasicServer.DATA, data);
+
+    return error;
+  }
+
+  private ObjectNode data(String exceptionTypeName, String... keyValuePairs) {
+    ObjectNode data = mapper.createObjectNode();
+    if (exceptionTypeName != null)
+      data.set(JsonRpcBasicServer.EXCEPTION_TYPE_NAME, new TextNode(exceptionTypeName));
+    for (String pair : keyValuePairs) {
+      String[] parts = pair.split("=");
+      data.set(parts[0], new TextNode(parts[1]));
+    }
+
+    return data;
+  }
+}

--- a/json-rpc-core/src/test/java/com/amazonaws/blox/jsonrpc/ResolverIntegrationTest.java
+++ b/json-rpc-core/src/test/java/com/amazonaws/blox/jsonrpc/ResolverIntegrationTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.jsonrpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.amazonaws.blox.jsonrpc.fixtures.PojoService;
+import com.amazonaws.blox.jsonrpc.fixtures.PojoTestException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.googlecode.jsonrpc4j.ErrorResolver;
+import com.googlecode.jsonrpc4j.ErrorResolver.JsonError;
+import com.googlecode.jsonrpc4j.ExceptionResolver;
+import com.googlecode.jsonrpc4j.JsonRpcBasicServer;
+import java.util.Collections;
+import org.junit.Test;
+
+public class ResolverIntegrationTest {
+  ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  public void clientSideResolverResolvesServerSideErrors() throws Exception {
+    ErrorResolver server = new PojoErrorResolver(mapper);
+    ExceptionResolver client = new PojoExceptionResolver(mapper);
+
+    PojoTestException originalException = new PojoTestException("alpha", "beta");
+
+    JsonError originalError =
+        server.resolveError(
+            originalException,
+            PojoService.class.getMethod("pojoCall", String.class),
+            Collections.emptyList());
+
+    ObjectNode response = wrapErrorAsResponse(originalError);
+
+    Throwable deserializedThrowable = client.resolveException(response);
+
+    assertThat(deserializedThrowable)
+        .isInstanceOf(PojoTestException.class)
+        .isEqualToComparingFieldByField(originalException);
+  }
+
+  private ObjectNode wrapErrorAsResponse(final JsonError originalError) {
+    ObjectNode response = mapper.createObjectNode();
+    response.set(JsonRpcBasicServer.ERROR, mapper.valueToTree(originalError));
+    return response;
+  }
+}

--- a/json-rpc-core/src/test/java/com/amazonaws/blox/jsonrpc/fixtures/PojoService.java
+++ b/json-rpc-core/src/test/java/com/amazonaws/blox/jsonrpc/fixtures/PojoService.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.jsonrpc.fixtures;
+
+public interface PojoService {
+  String pojoCall(String input) throws PojoTestException;
+
+  String nonPojoCall(String input);
+}

--- a/json-rpc-core/src/test/java/com/amazonaws/blox/jsonrpc/fixtures/PojoTestException.java
+++ b/json-rpc-core/src/test/java/com/amazonaws/blox/jsonrpc/fixtures/PojoTestException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.jsonrpc.fixtures;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class PojoTestException extends Exception {
+  private final String someValue;
+  private final String anotherValue;
+
+  @JsonCreator
+  public PojoTestException(
+      @JsonProperty("someValue") String someValue,
+      @JsonProperty("anotherValue") String anotherValue) {
+    this(someValue, anotherValue, null);
+  }
+
+  public PojoTestException(String someValue, String anotherValue, Throwable cause) {
+    super(someValue + ":" + anotherValue, cause);
+    this.someValue = someValue;
+    this.anotherValue = anotherValue;
+  }
+}

--- a/json-rpc-core/src/test/java/com/amazonaws/blox/test/JsonNodeAssert.java
+++ b/json-rpc-core/src/test/java/com/amazonaws/blox/test/JsonNodeAssert.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.function.Function;
+import org.assertj.core.api.AbstractAssert;
+
+public class JsonNodeAssert extends AbstractAssert<JsonNodeAssert, JsonNode> {
+  public JsonNodeAssert(final JsonNode actual) {
+    super(actual, JsonNodeAssert.class);
+  }
+
+  public static JsonNodeAssert assertThat(JsonNode actual) {
+    return new JsonNodeAssert(actual);
+  }
+
+  public JsonNodeAssert isObject() {
+    isNotNull();
+
+    if (!actual.isObject()) {
+      failWithMessage("Expected node to be an Object node, but was not");
+    }
+
+    return this;
+  }
+
+  public JsonNodeAssert hasNoField(String name) {
+    if (actual.has(name)) {
+      failWithMessage("Expected no field named <%s>, but found a field with that name.", name);
+    }
+
+    return this;
+  }
+
+  public JsonNodeAssert hasField(String name) {
+    if (!actual.has(name)) {
+      failWithMessage(
+          "Expected a field named <%s>, but did not find a field with that name.", name);
+    }
+
+    return this;
+  }
+
+  public JsonNodeAssert hasField(String name, String expected) {
+    return hasField(name, JsonNode::asText, expected);
+  }
+
+  public JsonNodeAssert hasField(String name, Integer expected) {
+    return hasField(name, JsonNode::asInt, expected);
+  }
+
+  private <T> JsonNodeAssert hasField(String name, Function<JsonNode, T> extractor, T expected) {
+    isObject();
+    hasField(name);
+
+    JsonNode node = actual.get(name);
+    if (!extractor.apply(node).equals(expected)) {
+      failWithMessage(
+          "Expected field <%s> to have value <%s>, but was <%s>", name, expected, actual);
+    }
+
+    return this;
+  }
+
+  public JsonNodeAssert hasNullField(final String name) {
+    isObject();
+    hasField(name);
+
+    JsonNode node = actual.get(name);
+    if (!node.isNull()) {
+      failWithMessage("Expected field <%s> to be null, but was <%s>", name, node);
+    }
+
+    return this;
+  }
+}

--- a/json-rpc-lambda-client/build.gradle
+++ b/json-rpc-lambda-client/build.gradle
@@ -5,7 +5,7 @@ plugins {
 description 'Blox DataService Client'
 
 dependencies {
-    compile "com.github.briandilley.jsonrpc4j:jsonrpc4j:+"
+    compile project(":json-rpc-core")
 
     compile "software.amazon.awssdk:lambda"
 

--- a/json-rpc-lambda-client/src/main/java/com/amazonaws/blox/jsonrpc/JsonRpcLambdaClient.java
+++ b/json-rpc-lambda-client/src/main/java/com/amazonaws/blox/jsonrpc/JsonRpcLambdaClient.java
@@ -16,8 +16,10 @@ package com.amazonaws.blox.jsonrpc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream;
+import com.googlecode.jsonrpc4j.DefaultExceptionResolver;
 import com.googlecode.jsonrpc4j.IJsonRpcClient;
 import com.googlecode.jsonrpc4j.JsonRpcClient;
+import com.googlecode.jsonrpc4j.MultipleExceptionResolver;
 import com.googlecode.jsonrpc4j.ProxyUtil;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -52,7 +54,11 @@ public class JsonRpcLambdaClient {
   public JsonRpcLambdaClient(ObjectMapper mapper, LambdaAsyncClient lambda, String functionName) {
     this.lambda = lambda;
     this.functionName = functionName;
-    this.streamClient = new JsonRpcClient(mapper);
+    this.streamClient =
+        new JsonRpcClient(
+            mapper,
+            new MultipleExceptionResolver(
+                new PojoExceptionResolver(mapper), DefaultExceptionResolver.INSTANCE));
   }
 
   /**

--- a/json-rpc-lambda-server/src/main/java/com/amazonaws/blox/jsonrpc/JsonRpcLambdaHandler.java
+++ b/json-rpc-lambda-server/src/main/java/com/amazonaws/blox/jsonrpc/JsonRpcLambdaHandler.java
@@ -17,7 +17,9 @@ package com.amazonaws.blox.jsonrpc;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.googlecode.jsonrpc4j.DefaultErrorResolver;
 import com.googlecode.jsonrpc4j.JsonRpcBasicServer;
+import com.googlecode.jsonrpc4j.MultipleErrorResolver;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -40,6 +42,8 @@ public class JsonRpcLambdaHandler<T> implements RequestStreamHandler {
   public JsonRpcLambdaHandler(ObjectMapper mapper, Class<T> serviceClass, T service) {
     this.service = service;
     this.server = new JsonRpcBasicServer(mapper, this.service, serviceClass);
+    this.server.setErrorResolver(
+        new MultipleErrorResolver(new PojoErrorResolver(mapper), DefaultErrorResolver.INSTANCE));
   }
 
   private static ObjectMapper defaultObjectMapper() {

--- a/json-rpc-lambda-server/src/test/java/com/amazonaws/blox/jsonrpc/ErrorMappingIntegrationTest.java
+++ b/json-rpc-lambda-server/src/test/java/com/amazonaws/blox/jsonrpc/ErrorMappingIntegrationTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.jsonrpc;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.amazonaws.blox.jsonrpc.fixtures.TestException;
+import com.amazonaws.blox.jsonrpc.fixtures.TestService;
+import com.amazonaws.blox.test.FakeLambdaClient;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+public class ErrorMappingIntegrationTest {
+  ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  public void itMapsPojoExceptionsFromFailingMethods() {
+    TestService server =
+        (input) -> {
+          throw new TestException(input, "beta");
+        };
+
+    JsonRpcLambdaHandler<TestService> handler =
+        new JsonRpcLambdaHandler<>(mapper, TestService.class, server);
+    JsonRpcLambdaClient lambdaClient =
+        new JsonRpcLambdaClient(mapper, new FakeLambdaClient<>(handler), "foo");
+
+    TestService client = lambdaClient.newProxy(TestService.class);
+
+    assertThatThrownBy(() -> client.throwsException("foo"))
+        .isInstanceOf(TestException.class)
+        .hasMessage("foo:beta")
+        .hasFieldOrPropertyWithValue("value", "foo")
+        .hasFieldOrPropertyWithValue("otherValue", "beta");
+  }
+}

--- a/json-rpc-lambda-server/src/test/java/com/amazonaws/blox/jsonrpc/fixtures/TestException.java
+++ b/json-rpc-lambda-server/src/test/java/com/amazonaws/blox/jsonrpc/fixtures/TestException.java
@@ -12,25 +12,23 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-package com.amazonaws.blox.dataservicemodel.v1.exception;
+package com.amazonaws.blox.jsonrpc.fixtures;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 @Getter
-public class ResourceNotFoundException extends ClientException {
-
-  private String resourceType;
-  private String resourceId;
+public class TestException extends Exception {
+  private final String value;
+  private final String otherValue;
 
   @JsonCreator
-  public ResourceNotFoundException(
-      @JsonProperty("resourceType") String resourceType,
-      @JsonProperty("resourceId") String resourceId) {
-    super(String.format("%s with id %s could not be found", resourceType, resourceId));
-
-    this.resourceType = resourceType;
-    this.resourceId = resourceId;
+  public TestException(
+      @JsonProperty("value") final String value,
+      @JsonProperty("otherValue") final String otherValue) {
+    super(value + ":" + otherValue);
+    this.value = value;
+    this.otherValue = otherValue;
   }
 }

--- a/json-rpc-lambda-server/src/test/java/com/amazonaws/blox/jsonrpc/fixtures/TestService.java
+++ b/json-rpc-lambda-server/src/test/java/com/amazonaws/blox/jsonrpc/fixtures/TestService.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.jsonrpc.fixtures;
+
+public interface TestService {
+
+  String throwsException(String input) throws TestException;
+}

--- a/json-rpc-lambda-server/src/test/java/com/amazonaws/blox/test/FakeLambdaClient.java
+++ b/json-rpc-lambda-server/src/test/java/com/amazonaws/blox/test/FakeLambdaClient.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.test;
+
+import com.amazonaws.blox.jsonrpc.JsonRpcLambdaHandler;
+import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import lombok.SneakyThrows;
+import software.amazon.awssdk.services.lambda.LambdaAsyncClient;
+import software.amazon.awssdk.services.lambda.model.InvokeRequest;
+import software.amazon.awssdk.services.lambda.model.InvokeResponse;
+
+public class FakeLambdaClient<T> implements LambdaAsyncClient {
+  private final JsonRpcLambdaHandler<T> handler;
+
+  public FakeLambdaClient(final JsonRpcLambdaHandler<T> handler) {
+    this.handler = handler;
+  }
+
+  @Override
+  public void close() {}
+
+  @Override
+  @SneakyThrows
+  public CompletableFuture<InvokeResponse> invoke(final InvokeRequest invokeRequest) {
+    ByteBufferBackedInputStream inputStream =
+        new ByteBufferBackedInputStream(invokeRequest.payload());
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+    handler.handleRequest(inputStream, outputStream, null);
+
+    return CompletableFuture.completedFuture(
+        InvokeResponse.builder().payload(ByteBuffer.wrap(outputStream.toByteArray())).build());
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,4 +14,5 @@ include 'json-rpc-lambda-server'
 include 'json-rpc-lambda-client'
 include 'lambda-spring'
 include 'lambda-logging'
+include 'json-rpc-core'
 


### PR DESCRIPTION
This adds Jackson-based (de)serialization for JSON-RPC servers and clients that will serialize/deserialize Throwable instances that have custom fields correctly.

#### Testing
Apart from new unit tests, the last commit in the PR fixes the existing DataService integration tests that used to fail because exception mapping didn't work. Now `gradle cucumberTest` succeeds.

Fixes #315 