### PR TITLE
Add UpdateEnvironment API to frontend

### DIFF
--- a/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/wrappers/UpdateEnvironmentRequest.java
+++ b/data-service-model/src/main/java/com/amazonaws/blox/dataservicemodel/v1/model/wrappers/UpdateEnvironmentRequest.java
@@ -15,16 +15,19 @@
 package com.amazonaws.blox.dataservicemodel.v1.model.wrappers;
 
 import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentId;
-import com.amazonaws.blox.dataservicemodel.v1.model.InstanceGroup;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
-import lombok.Value;
 
-@Value
+@Data
 @Builder
+// required for builder
+@AllArgsConstructor
+// required for mapstruct
+@NoArgsConstructor
 public class UpdateEnvironmentRequest {
   @NonNull private EnvironmentId environmentId;
-  @NonNull private String role;
   @NonNull private String taskDefinition;
-  @NonNull private InstanceGroup instanceGroup;
 }

--- a/frontend-service-client/src/main/java/com/amazonaws/blox/AbstractBlox.java
+++ b/frontend-service-client/src/main/java/com/amazonaws/blox/AbstractBlox.java
@@ -64,6 +64,11 @@ public class AbstractBlox implements Blox {
     }
 
     @Override
+    public UpdateEnvironmentResult updateEnvironment(UpdateEnvironmentRequest request) {
+        throw new java.lang.UnsupportedOperationException();
+    }
+
+    @Override
     public void shutdown() {
         throw new java.lang.UnsupportedOperationException();
     }

--- a/frontend-service-client/src/main/java/com/amazonaws/blox/Blox.java
+++ b/frontend-service-client/src/main/java/com/amazonaws/blox/Blox.java
@@ -3,26 +3,14 @@
 */
 package com.amazonaws.blox;
 
-import com.amazonaws.blox.model.CreateEnvironmentRequest;
-import com.amazonaws.blox.model.CreateEnvironmentResult;
-import com.amazonaws.blox.model.DeleteEnvironmentRequest;
-import com.amazonaws.blox.model.DeleteEnvironmentResult;
-import com.amazonaws.blox.model.DescribeEnvironmentDeploymentRequest;
-import com.amazonaws.blox.model.DescribeEnvironmentDeploymentResult;
-import com.amazonaws.blox.model.DescribeEnvironmentRequest;
-import com.amazonaws.blox.model.DescribeEnvironmentResult;
-import com.amazonaws.blox.model.DescribeEnvironmentRevisionRequest;
-import com.amazonaws.blox.model.DescribeEnvironmentRevisionResult;
-import com.amazonaws.blox.model.ListEnvironmentDeploymentsRequest;
-import com.amazonaws.blox.model.ListEnvironmentDeploymentsResult;
-import com.amazonaws.blox.model.ListEnvironmentRevisionsRequest;
-import com.amazonaws.blox.model.ListEnvironmentRevisionsResult;
-import com.amazonaws.blox.model.ListEnvironmentsRequest;
-import com.amazonaws.blox.model.ListEnvironmentsResult;
-import com.amazonaws.blox.model.ResourceNotFoundException;
-import com.amazonaws.blox.model.StartDeploymentRequest;
-import com.amazonaws.blox.model.StartDeploymentResult;
 import javax.annotation.Generated;
+
+import com.amazonaws.*;
+import com.amazonaws.opensdk.*;
+import com.amazonaws.opensdk.model.*;
+import com.amazonaws.regions.*;
+
+import com.amazonaws.blox.model.*;
 
 /**
  * Interface for accessing Blox.
@@ -111,6 +99,15 @@ public interface Blox {
      *      API Documentation</a>
      */
     StartDeploymentResult startDeployment(StartDeploymentRequest startDeploymentRequest);
+
+    /**
+     * @param updateEnvironmentRequest
+     * @return Result of the updateEnvironment operation returned by the service.
+     * @sample Blox.updateEnvironment
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/ecs-blox-v2017-07-11/updateEnvironment" target="_top">AWS
+     *      API Documentation</a>
+     */
+    UpdateEnvironmentResult updateEnvironment(UpdateEnvironmentRequest updateEnvironmentRequest);
 
     /**
      * @return Create new instance of builder with all defaults set.

--- a/frontend-service-client/src/main/java/com/amazonaws/blox/BloxClient.java
+++ b/frontend-service-client/src/main/java/com/amazonaws/blox/BloxClient.java
@@ -3,57 +3,38 @@
 */
 package com.amazonaws.blox;
 
-import com.amazonaws.SdkBaseException;
+import java.net.*;
+import java.util.*;
+
+import javax.annotation.Generated;
+
+import org.apache.commons.logging.*;
+
+import com.amazonaws.*;
+import com.amazonaws.opensdk.*;
+import com.amazonaws.opensdk.model.*;
+import com.amazonaws.opensdk.protect.model.transform.*;
+import com.amazonaws.auth.*;
+import com.amazonaws.handlers.*;
+import com.amazonaws.http.*;
+import com.amazonaws.internal.*;
+import com.amazonaws.metrics.*;
+import com.amazonaws.regions.*;
+import com.amazonaws.transform.*;
+import com.amazonaws.util.*;
+import com.amazonaws.protocol.json.*;
+
 import com.amazonaws.annotation.ThreadSafe;
-import com.amazonaws.blox.model.CreateEnvironmentRequest;
-import com.amazonaws.blox.model.CreateEnvironmentResult;
-import com.amazonaws.blox.model.DeleteEnvironmentRequest;
-import com.amazonaws.blox.model.DeleteEnvironmentResult;
-import com.amazonaws.blox.model.DescribeEnvironmentDeploymentRequest;
-import com.amazonaws.blox.model.DescribeEnvironmentDeploymentResult;
-import com.amazonaws.blox.model.DescribeEnvironmentRequest;
-import com.amazonaws.blox.model.DescribeEnvironmentResult;
-import com.amazonaws.blox.model.DescribeEnvironmentRevisionRequest;
-import com.amazonaws.blox.model.DescribeEnvironmentRevisionResult;
-import com.amazonaws.blox.model.ListEnvironmentDeploymentsRequest;
-import com.amazonaws.blox.model.ListEnvironmentDeploymentsResult;
-import com.amazonaws.blox.model.ListEnvironmentRevisionsRequest;
-import com.amazonaws.blox.model.ListEnvironmentRevisionsResult;
-import com.amazonaws.blox.model.ListEnvironmentsRequest;
-import com.amazonaws.blox.model.ListEnvironmentsResult;
-import com.amazonaws.blox.model.ResourceNotFoundException;
-import com.amazonaws.blox.model.StartDeploymentRequest;
-import com.amazonaws.blox.model.StartDeploymentResult;
-import com.amazonaws.blox.model.transform.CreateEnvironmentRequestProtocolMarshaller;
-import com.amazonaws.blox.model.transform.CreateEnvironmentResultJsonUnmarshaller;
-import com.amazonaws.blox.model.transform.DeleteEnvironmentRequestProtocolMarshaller;
-import com.amazonaws.blox.model.transform.DeleteEnvironmentResultJsonUnmarshaller;
-import com.amazonaws.blox.model.transform.DescribeEnvironmentDeploymentRequestProtocolMarshaller;
-import com.amazonaws.blox.model.transform.DescribeEnvironmentDeploymentResultJsonUnmarshaller;
-import com.amazonaws.blox.model.transform.DescribeEnvironmentRequestProtocolMarshaller;
-import com.amazonaws.blox.model.transform.DescribeEnvironmentResultJsonUnmarshaller;
-import com.amazonaws.blox.model.transform.DescribeEnvironmentRevisionRequestProtocolMarshaller;
-import com.amazonaws.blox.model.transform.DescribeEnvironmentRevisionResultJsonUnmarshaller;
-import com.amazonaws.blox.model.transform.ListEnvironmentDeploymentsRequestProtocolMarshaller;
-import com.amazonaws.blox.model.transform.ListEnvironmentDeploymentsResultJsonUnmarshaller;
-import com.amazonaws.blox.model.transform.ListEnvironmentRevisionsRequestProtocolMarshaller;
-import com.amazonaws.blox.model.transform.ListEnvironmentRevisionsResultJsonUnmarshaller;
-import com.amazonaws.blox.model.transform.ListEnvironmentsRequestProtocolMarshaller;
-import com.amazonaws.blox.model.transform.ListEnvironmentsResultJsonUnmarshaller;
-import com.amazonaws.blox.model.transform.StartDeploymentRequestProtocolMarshaller;
-import com.amazonaws.blox.model.transform.StartDeploymentResultJsonUnmarshaller;
 import com.amazonaws.client.AwsSyncClientParams;
-import com.amazonaws.client.ClientExecutionParams;
+
 import com.amazonaws.client.ClientHandler;
 import com.amazonaws.client.ClientHandlerParams;
-import com.amazonaws.http.HttpResponseHandler;
+import com.amazonaws.client.ClientExecutionParams;
 import com.amazonaws.opensdk.protect.client.SdkClientHandler;
-import com.amazonaws.protocol.json.JsonClientMetadata;
-import com.amazonaws.protocol.json.JsonErrorResponseMetadata;
-import com.amazonaws.protocol.json.JsonErrorShapeMetadata;
-import com.amazonaws.protocol.json.JsonOperationMetadata;
-import java.util.Arrays;
-import javax.annotation.Generated;
+import com.amazonaws.SdkBaseException;
+
+import com.amazonaws.blox.model.*;
+import com.amazonaws.blox.model.transform.*;
 
 /**
  * Client for accessing Blox. All service calls made using this client are blocking, and will not return until the
@@ -263,6 +244,25 @@ class BloxClient implements Blox {
         return clientHandler.execute(new ClientExecutionParams<StartDeploymentRequest, StartDeploymentResult>()
                 .withMarshaller(new StartDeploymentRequestProtocolMarshaller(protocolFactory)).withResponseHandler(responseHandler)
                 .withErrorResponseHandler(errorResponseHandler).withInput(startDeploymentRequest));
+    }
+
+    /**
+     * @param updateEnvironmentRequest
+     * @return Result of the updateEnvironment operation returned by the service.
+     * @sample Blox.updateEnvironment
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/ecs-blox-v2017-07-11/updateEnvironment" target="_top">AWS
+     *      API Documentation</a>
+     */
+    @Override
+    public UpdateEnvironmentResult updateEnvironment(UpdateEnvironmentRequest updateEnvironmentRequest) {
+        HttpResponseHandler<UpdateEnvironmentResult> responseHandler = protocolFactory.createResponseHandler(new JsonOperationMetadata().withPayloadJson(true)
+                .withHasStreamingSuccessResponse(false), new UpdateEnvironmentResultJsonUnmarshaller());
+
+        HttpResponseHandler<SdkBaseException> errorResponseHandler = createErrorResponseHandler();
+
+        return clientHandler.execute(new ClientExecutionParams<UpdateEnvironmentRequest, UpdateEnvironmentResult>()
+                .withMarshaller(new UpdateEnvironmentRequestProtocolMarshaller(protocolFactory)).withResponseHandler(responseHandler)
+                .withErrorResponseHandler(errorResponseHandler).withInput(updateEnvironmentRequest));
     }
 
     /**

--- a/frontend-service-client/src/main/java/com/amazonaws/blox/model/UpdateEnvironmentRequest.java
+++ b/frontend-service-client/src/main/java/com/amazonaws/blox/model/UpdateEnvironmentRequest.java
@@ -1,0 +1,183 @@
+/**
+
+*/
+package com.amazonaws.blox.model;
+
+import java.io.Serializable;
+import javax.annotation.Generated;
+
+import com.amazonaws.auth.RequestSigner;
+import com.amazonaws.opensdk.protect.auth.RequestSignerAware;
+
+/**
+ * 
+ * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/ecs-blox-v2017-07-11/UpdateEnvironment" target="_top">AWS API
+ *      Documentation</a>
+ */
+@Generated("com.amazonaws:aws-java-sdk-code-generator")
+public class UpdateEnvironmentRequest extends com.amazonaws.opensdk.BaseRequest implements Serializable, Cloneable, RequestSignerAware {
+
+    private String cluster;
+
+    private String environmentName;
+
+    private String taskDefinition;
+
+    /**
+     * @param cluster
+     */
+
+    public void setCluster(String cluster) {
+        this.cluster = cluster;
+    }
+
+    /**
+     * @return
+     */
+
+    public String getCluster() {
+        return this.cluster;
+    }
+
+    /**
+     * @param cluster
+     * @return Returns a reference to this object so that method calls can be chained together.
+     */
+
+    public UpdateEnvironmentRequest cluster(String cluster) {
+        setCluster(cluster);
+        return this;
+    }
+
+    /**
+     * @param environmentName
+     */
+
+    public void setEnvironmentName(String environmentName) {
+        this.environmentName = environmentName;
+    }
+
+    /**
+     * @return
+     */
+
+    public String getEnvironmentName() {
+        return this.environmentName;
+    }
+
+    /**
+     * @param environmentName
+     * @return Returns a reference to this object so that method calls can be chained together.
+     */
+
+    public UpdateEnvironmentRequest environmentName(String environmentName) {
+        setEnvironmentName(environmentName);
+        return this;
+    }
+
+    /**
+     * @param taskDefinition
+     */
+
+    public void setTaskDefinition(String taskDefinition) {
+        this.taskDefinition = taskDefinition;
+    }
+
+    /**
+     * @return
+     */
+
+    public String getTaskDefinition() {
+        return this.taskDefinition;
+    }
+
+    /**
+     * @param taskDefinition
+     * @return Returns a reference to this object so that method calls can be chained together.
+     */
+
+    public UpdateEnvironmentRequest taskDefinition(String taskDefinition) {
+        setTaskDefinition(taskDefinition);
+        return this;
+    }
+
+    /**
+     * Returns a string representation of this object; useful for testing and debugging.
+     *
+     * @return A string representation of this object.
+     *
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        if (getCluster() != null)
+            sb.append("Cluster: ").append(getCluster()).append(",");
+        if (getEnvironmentName() != null)
+            sb.append("EnvironmentName: ").append(getEnvironmentName()).append(",");
+        if (getTaskDefinition() != null)
+            sb.append("TaskDefinition: ").append(getTaskDefinition());
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+
+        if (obj instanceof UpdateEnvironmentRequest == false)
+            return false;
+        UpdateEnvironmentRequest other = (UpdateEnvironmentRequest) obj;
+        if (other.getCluster() == null ^ this.getCluster() == null)
+            return false;
+        if (other.getCluster() != null && other.getCluster().equals(this.getCluster()) == false)
+            return false;
+        if (other.getEnvironmentName() == null ^ this.getEnvironmentName() == null)
+            return false;
+        if (other.getEnvironmentName() != null && other.getEnvironmentName().equals(this.getEnvironmentName()) == false)
+            return false;
+        if (other.getTaskDefinition() == null ^ this.getTaskDefinition() == null)
+            return false;
+        if (other.getTaskDefinition() != null && other.getTaskDefinition().equals(this.getTaskDefinition()) == false)
+            return false;
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int hashCode = 1;
+
+        hashCode = prime * hashCode + ((getCluster() == null) ? 0 : getCluster().hashCode());
+        hashCode = prime * hashCode + ((getEnvironmentName() == null) ? 0 : getEnvironmentName().hashCode());
+        hashCode = prime * hashCode + ((getTaskDefinition() == null) ? 0 : getTaskDefinition().hashCode());
+        return hashCode;
+    }
+
+    @Override
+    public UpdateEnvironmentRequest clone() {
+        return (UpdateEnvironmentRequest) super.clone();
+    }
+
+    @Override
+    public Class<? extends RequestSigner> signerType() {
+        return com.amazonaws.opensdk.protect.auth.IamRequestSigner.class;
+    }
+
+    /**
+     * Set the configuration for this request.
+     *
+     * @param sdkRequestConfig
+     *        Request configuration.
+     * @return This object for method chaining.
+     */
+    public UpdateEnvironmentRequest sdkRequestConfig(com.amazonaws.opensdk.SdkRequestConfig sdkRequestConfig) {
+        super.sdkRequestConfig(sdkRequestConfig);
+        return this;
+    }
+
+}

--- a/frontend-service-client/src/main/java/com/amazonaws/blox/model/UpdateEnvironmentResult.java
+++ b/frontend-service-client/src/main/java/com/amazonaws/blox/model/UpdateEnvironmentResult.java
@@ -1,0 +1,97 @@
+/**
+
+*/
+package com.amazonaws.blox.model;
+
+import java.io.Serializable;
+import javax.annotation.Generated;
+
+/**
+ * 
+ * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/ecs-blox-v2017-07-11/UpdateEnvironment" target="_top">AWS API
+ *      Documentation</a>
+ */
+@Generated("com.amazonaws:aws-java-sdk-code-generator")
+public class UpdateEnvironmentResult extends com.amazonaws.opensdk.BaseResult implements Serializable, Cloneable {
+
+    private String environmentRevisionId;
+
+    /**
+     * @param environmentRevisionId
+     */
+
+    public void setEnvironmentRevisionId(String environmentRevisionId) {
+        this.environmentRevisionId = environmentRevisionId;
+    }
+
+    /**
+     * @return
+     */
+
+    public String getEnvironmentRevisionId() {
+        return this.environmentRevisionId;
+    }
+
+    /**
+     * @param environmentRevisionId
+     * @return Returns a reference to this object so that method calls can be chained together.
+     */
+
+    public UpdateEnvironmentResult environmentRevisionId(String environmentRevisionId) {
+        setEnvironmentRevisionId(environmentRevisionId);
+        return this;
+    }
+
+    /**
+     * Returns a string representation of this object; useful for testing and debugging.
+     *
+     * @return A string representation of this object.
+     *
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        if (getEnvironmentRevisionId() != null)
+            sb.append("EnvironmentRevisionId: ").append(getEnvironmentRevisionId());
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+
+        if (obj instanceof UpdateEnvironmentResult == false)
+            return false;
+        UpdateEnvironmentResult other = (UpdateEnvironmentResult) obj;
+        if (other.getEnvironmentRevisionId() == null ^ this.getEnvironmentRevisionId() == null)
+            return false;
+        if (other.getEnvironmentRevisionId() != null && other.getEnvironmentRevisionId().equals(this.getEnvironmentRevisionId()) == false)
+            return false;
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int hashCode = 1;
+
+        hashCode = prime * hashCode + ((getEnvironmentRevisionId() == null) ? 0 : getEnvironmentRevisionId().hashCode());
+        return hashCode;
+    }
+
+    @Override
+    public UpdateEnvironmentResult clone() {
+        try {
+            return (UpdateEnvironmentResult) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new IllegalStateException("Got a CloneNotSupportedException from Object.clone() " + "even though we're Cloneable!", e);
+        }
+    }
+
+}

--- a/frontend-service-client/src/main/java/com/amazonaws/blox/model/transform/UpdateEnvironmentRequestMarshaller.java
+++ b/frontend-service-client/src/main/java/com/amazonaws/blox/model/transform/UpdateEnvironmentRequestMarshaller.java
@@ -1,0 +1,52 @@
+/**
+
+*/
+package com.amazonaws.blox.model.transform;
+
+import javax.annotation.Generated;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.blox.model.*;
+
+import com.amazonaws.protocol.*;
+import com.amazonaws.annotation.SdkInternalApi;
+
+/**
+ * UpdateEnvironmentRequestMarshaller
+ */
+@Generated("com.amazonaws:aws-java-sdk-code-generator")
+@SdkInternalApi
+public class UpdateEnvironmentRequestMarshaller {
+
+    private static final MarshallingInfo<String> CLUSTER_BINDING = MarshallingInfo.builder(MarshallingType.STRING).marshallLocation(MarshallLocation.PATH)
+            .marshallLocationName("cluster").build();
+    private static final MarshallingInfo<String> ENVIRONMENTNAME_BINDING = MarshallingInfo.builder(MarshallingType.STRING)
+            .marshallLocation(MarshallLocation.PAYLOAD).marshallLocationName("environmentName").build();
+    private static final MarshallingInfo<String> TASKDEFINITION_BINDING = MarshallingInfo.builder(MarshallingType.STRING)
+            .marshallLocation(MarshallLocation.PAYLOAD).marshallLocationName("taskDefinition").build();
+
+    private static final UpdateEnvironmentRequestMarshaller instance = new UpdateEnvironmentRequestMarshaller();
+
+    public static UpdateEnvironmentRequestMarshaller getInstance() {
+        return instance;
+    }
+
+    /**
+     * Marshall the given parameter object.
+     */
+    public void marshall(UpdateEnvironmentRequest updateEnvironmentRequest, ProtocolMarshaller protocolMarshaller) {
+
+        if (updateEnvironmentRequest == null) {
+            throw new SdkClientException("Invalid argument passed to marshall(...)");
+        }
+
+        try {
+            protocolMarshaller.marshall(updateEnvironmentRequest.getCluster(), CLUSTER_BINDING);
+            protocolMarshaller.marshall(updateEnvironmentRequest.getEnvironmentName(), ENVIRONMENTNAME_BINDING);
+            protocolMarshaller.marshall(updateEnvironmentRequest.getTaskDefinition(), TASKDEFINITION_BINDING);
+        } catch (Exception e) {
+            throw new SdkClientException("Unable to marshall request to JSON: " + e.getMessage(), e);
+        }
+    }
+
+}

--- a/frontend-service-client/src/main/java/com/amazonaws/blox/model/transform/UpdateEnvironmentRequestProtocolMarshaller.java
+++ b/frontend-service-client/src/main/java/com/amazonaws/blox/model/transform/UpdateEnvironmentRequestProtocolMarshaller.java
@@ -1,0 +1,53 @@
+/**
+
+*/
+package com.amazonaws.blox.model.transform;
+
+import javax.annotation.Generated;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.Request;
+
+import com.amazonaws.http.HttpMethodName;
+import com.amazonaws.blox.model.*;
+import com.amazonaws.transform.Marshaller;
+
+import com.amazonaws.protocol.*;
+import com.amazonaws.annotation.SdkInternalApi;
+
+/**
+ * UpdateEnvironmentRequest Marshaller
+ */
+@Generated("com.amazonaws:aws-java-sdk-code-generator")
+@SdkInternalApi
+public class UpdateEnvironmentRequestProtocolMarshaller implements Marshaller<Request<UpdateEnvironmentRequest>, UpdateEnvironmentRequest> {
+
+    private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder().protocol(Protocol.API_GATEWAY)
+            .requestUri("/alpha/v1/{cluster}/environments/{environmentName}").httpMethodName(HttpMethodName.PUT).hasExplicitPayloadMember(false)
+            .hasPayloadMembers(true).serviceName("Blox").build();
+
+    private final com.amazonaws.opensdk.protect.protocol.ApiGatewayProtocolFactoryImpl protocolFactory;
+
+    public UpdateEnvironmentRequestProtocolMarshaller(com.amazonaws.opensdk.protect.protocol.ApiGatewayProtocolFactoryImpl protocolFactory) {
+        this.protocolFactory = protocolFactory;
+    }
+
+    public Request<UpdateEnvironmentRequest> marshall(UpdateEnvironmentRequest updateEnvironmentRequest) {
+
+        if (updateEnvironmentRequest == null) {
+            throw new SdkClientException("Invalid argument passed to marshall(...)");
+        }
+
+        try {
+            final ProtocolRequestMarshaller<UpdateEnvironmentRequest> protocolMarshaller = protocolFactory.createProtocolMarshaller(SDK_OPERATION_BINDING,
+                    updateEnvironmentRequest);
+
+            protocolMarshaller.startMarshalling();
+            UpdateEnvironmentRequestMarshaller.getInstance().marshall(updateEnvironmentRequest, protocolMarshaller);
+            return protocolMarshaller.finishMarshalling();
+        } catch (Exception e) {
+            throw new SdkClientException("Unable to marshall request to JSON: " + e.getMessage(), e);
+        }
+    }
+
+}

--- a/frontend-service-client/src/main/java/com/amazonaws/blox/model/transform/UpdateEnvironmentResultJsonUnmarshaller.java
+++ b/frontend-service-client/src/main/java/com/amazonaws/blox/model/transform/UpdateEnvironmentResultJsonUnmarshaller.java
@@ -1,0 +1,65 @@
+/**
+
+*/
+package com.amazonaws.blox.model.transform;
+
+import java.math.*;
+
+import javax.annotation.Generated;
+
+import com.amazonaws.blox.model.*;
+import com.amazonaws.transform.SimpleTypeJsonUnmarshallers.*;
+import com.amazonaws.transform.*;
+
+import com.fasterxml.jackson.core.JsonToken;
+import static com.fasterxml.jackson.core.JsonToken.*;
+
+/**
+ * UpdateEnvironmentResult JSON Unmarshaller
+ */
+@Generated("com.amazonaws:aws-java-sdk-code-generator")
+public class UpdateEnvironmentResultJsonUnmarshaller implements Unmarshaller<UpdateEnvironmentResult, JsonUnmarshallerContext> {
+
+    public UpdateEnvironmentResult unmarshall(JsonUnmarshallerContext context) throws Exception {
+        UpdateEnvironmentResult updateEnvironmentResult = new UpdateEnvironmentResult();
+
+        int originalDepth = context.getCurrentDepth();
+        String currentParentElement = context.getCurrentParentElement();
+        int targetDepth = originalDepth + 1;
+
+        JsonToken token = context.getCurrentToken();
+        if (token == null)
+            token = context.nextToken();
+        if (token == VALUE_NULL) {
+            return updateEnvironmentResult;
+        }
+
+        while (true) {
+            if (token == null)
+                break;
+
+            if (token == FIELD_NAME || token == START_OBJECT) {
+                if (context.testExpression("environmentRevisionId", targetDepth)) {
+                    context.nextToken();
+                    updateEnvironmentResult.setEnvironmentRevisionId(context.getUnmarshaller(String.class).unmarshall(context));
+                }
+            } else if (token == END_ARRAY || token == END_OBJECT) {
+                if (context.getLastParsedParentElement() == null || context.getLastParsedParentElement().equals(currentParentElement)) {
+                    if (context.getCurrentDepth() <= originalDepth)
+                        break;
+                }
+            }
+            token = context.nextToken();
+        }
+
+        return updateEnvironmentResult;
+    }
+
+    private static UpdateEnvironmentResultJsonUnmarshaller instance;
+
+    public static UpdateEnvironmentResultJsonUnmarshaller getInstance() {
+        if (instance == null)
+            instance = new UpdateEnvironmentResultJsonUnmarshaller();
+        return instance;
+    }
+}

--- a/frontend-service/api/swagger.yml
+++ b/frontend-service/api/swagger.yml
@@ -111,6 +111,41 @@ paths:
         type: "aws_proxy"
         uri:
           Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${FrontendHandler.Arn}/invocations"
+    put:
+      summary: "Update an existing Environment"
+      description: ""
+      operationId: "updateEnvironment"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "cluster"
+        in: "path"
+        required: true
+        type: "string"
+      - name: "environmentName"
+        in: "path"
+        required: true
+        type: "string"
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/UpdateEnvironmentRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/UpdateEnvironmentResponse"
+      security:
+      - defaultAuthorization: []
+      x-amazon-apigateway-integration:
+        passthroughBehavior: "when_no_match"
+        httpMethod: "POST"
+        type: "aws_proxy"
+        uri:
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${FrontendHandler.Arn}/invocations"
     delete:
       summary: "Delete an Environment by name"
       description: ""
@@ -480,3 +515,15 @@ definitions:
       total:
         type: "integer"
         format: "int64"
+  UpdateEnvironmentRequest:
+    type: "object"
+    properties:
+      environmentName:
+        type: "string"
+      taskDefinition:
+        type: "string"
+  UpdateEnvironmentResponse:
+    type: "object"
+    properties:
+      environmentRevisionId:
+        type: "string"

--- a/frontend-service/src/main/java/com/amazonaws/blox/frontend/mappers/UpdateEnvironmentMapper.java
+++ b/frontend-service/src/main/java/com/amazonaws/blox/frontend/mappers/UpdateEnvironmentMapper.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.frontend.mappers;
+
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.UpdateEnvironmentRequest;
+import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.UpdateEnvironmentResponse;
+import com.amazonaws.blox.frontend.operations.UpdateEnvironment;
+import com.amazonaws.serverless.proxy.internal.model.ApiGatewayRequestContext;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper
+public interface UpdateEnvironmentMapper {
+  @Mapping(target = "environmentId.accountId", source = "context.accountId")
+  @Mapping(target = "environmentId.cluster", source = "cluster")
+  @Mapping(target = "environmentId.environmentName", source = "request.environmentName")
+  UpdateEnvironmentRequest toDataServiceRequest(
+      ApiGatewayRequestContext context,
+      String cluster,
+      String environmentName,
+      UpdateEnvironment.UpdateEnvironmentRequest request);
+
+  @Mapping(source = "environmentRevision.environmentRevisionId", target = "environmentRevisionId")
+  UpdateEnvironment.UpdateEnvironmentResponse fromDataServiceResponse(
+      UpdateEnvironmentResponse response);
+}

--- a/frontend-service/src/main/java/com/amazonaws/blox/frontend/operations/UpdateEnvironment.java
+++ b/frontend-service/src/main/java/com/amazonaws/blox/frontend/operations/UpdateEnvironment.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.frontend.operations;
+
+import com.amazonaws.blox.dataservicemodel.v1.exception.InvalidParameterException;
+import com.amazonaws.blox.dataservicemodel.v1.exception.ResourceNotFoundException;
+import com.amazonaws.blox.dataservicemodel.v1.exception.ServiceException;
+import com.amazonaws.blox.frontend.mappers.UpdateEnvironmentMapper;
+import io.swagger.annotations.ApiOperation;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class UpdateEnvironment extends EnvironmentController {
+  @Autowired UpdateEnvironmentMapper mapper;
+
+  @RequestMapping(
+    path = "/{environmentName}",
+    method = RequestMethod.PUT,
+    consumes = "application/json"
+  )
+  @ApiOperation(value = "Update an existing Environment")
+  public UpdateEnvironmentResponse updateEnvironment(
+      @PathVariable("cluster") String cluster,
+      @PathVariable("environmentName") String environmentName,
+      @RequestBody UpdateEnvironmentRequest request)
+      throws InvalidParameterException, ServiceException, ResourceNotFoundException {
+
+    return mapper.fromDataServiceResponse(
+        dataService.updateEnvironment(
+            mapper.toDataServiceRequest(
+                getApiGatewayRequestContext(), cluster, environmentName, request)));
+  }
+
+  @Data
+  @Builder
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class UpdateEnvironmentResponse {
+    private String environmentRevisionId;
+  }
+
+  @Data
+  @Builder
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class UpdateEnvironmentRequest {
+    private String environmentName;
+    private String taskDefinition;
+  }
+}

--- a/frontend-service/src/test/java/com/amazonaws/blox/frontend/operations/CreateEnvironmentTest.java
+++ b/frontend-service/src/test/java/com/amazonaws/blox/frontend/operations/CreateEnvironmentTest.java
@@ -20,14 +20,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.blox.dataservicemodel.v1.model.DeploymentConfiguration;
-import com.amazonaws.blox.dataservicemodel.v1.model.Environment;
 import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentId;
-import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentRevision;
 import com.amazonaws.blox.dataservicemodel.v1.model.InstanceGroup;
 import com.amazonaws.blox.frontend.mappers.CreateEnvironmentMapper;
 import com.amazonaws.blox.frontend.operations.CreateEnvironment.CreateEnvironmentRequest;
 import com.amazonaws.blox.frontend.operations.CreateEnvironment.CreateEnvironmentResponse;
-import java.time.Instant;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -51,26 +48,8 @@ public class CreateEnvironmentTest extends EnvironmentControllerTestCase {
         .thenReturn(
             com.amazonaws.blox.dataservicemodel.v1.model.wrappers.CreateEnvironmentResponse
                 .builder()
-                .environment(
-                    Environment.builder()
-                        .environmentId(id)
-                        .role(ROLE)
-                        .environmentType(ENVIRONMENT_TYPE)
-                        .environmentHealth(HEALTHY)
-                        .environmentStatus(STATUS)
-                        .deploymentMethod(DEPLOYMENT_METHOD)
-                        .deploymentConfiguration(deploymentConfiguration)
-                        .createdTime(Instant.now())
-                        .lastUpdatedTime(Instant.now())
-                        .build())
-                .environmentRevision(
-                    EnvironmentRevision.builder()
-                        .environmentId(id)
-                        .environmentRevisionId(ENVIRONMENT_REVISION_ID)
-                        .instanceGroup(instanceGroup)
-                        .taskDefinition(TASK_DEFINITION)
-                        .createdTime(Instant.now())
-                        .build())
+                .environment(environmentDS(id, deploymentConfiguration))
+                .environmentRevision(environmentRevisionDS(id, instanceGroup))
                 .build());
 
     CreateEnvironmentResponse response =

--- a/frontend-service/src/test/java/com/amazonaws/blox/frontend/operations/DescribeEnvironmentRevisionTest.java
+++ b/frontend-service/src/test/java/com/amazonaws/blox/frontend/operations/DescribeEnvironmentRevisionTest.java
@@ -23,7 +23,6 @@ import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentId;
 import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentRevision;
 import com.amazonaws.blox.frontend.mappers.DescribeEnvironmentRevisionMapper;
 import com.amazonaws.blox.frontend.operations.DescribeEnvironmentRevision.DescribeEnvironmentRevisionResponse;
-import java.time.Instant;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -41,13 +40,7 @@ public class DescribeEnvironmentRevisionTest extends EnvironmentControllerTestCa
             .build();
 
     EnvironmentRevision environmentRevision =
-        EnvironmentRevision.builder()
-            .environmentId(id)
-            .environmentRevisionId(ENVIRONMENT_REVISION_ID)
-            .instanceGroup(instanceGroupWithAttributeDS(ATTRIBUTE_NAME, ATTRIBUTE_VALUE))
-            .taskDefinition(TASK_DEFINITION)
-            .createdTime(Instant.now())
-            .build();
+        environmentRevisionDS(id, instanceGroupWithAttributeDS(ATTRIBUTE_NAME, ATTRIBUTE_VALUE));
 
     when(dataService.describeEnvironmentRevision(any()))
         .thenReturn(

--- a/frontend-service/src/test/java/com/amazonaws/blox/frontend/operations/EnvironmentControllerTestCase.java
+++ b/frontend-service/src/test/java/com/amazonaws/blox/frontend/operations/EnvironmentControllerTestCase.java
@@ -19,11 +19,15 @@ import static org.mockito.Mockito.mock;
 import com.amazonaws.blox.dataservicemodel.v1.client.DataService;
 import com.amazonaws.blox.dataservicemodel.v1.model.Attribute;
 import com.amazonaws.blox.dataservicemodel.v1.model.DeploymentConfiguration;
+import com.amazonaws.blox.dataservicemodel.v1.model.Environment;
+import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentId;
+import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentRevision;
 import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentType;
 import com.amazonaws.blox.dataservicemodel.v1.model.InstanceGroup;
 import com.amazonaws.blox.frontend.MapperConfiguration;
 import com.amazonaws.serverless.proxy.internal.model.ApiGatewayRequestContext;
 import com.amazonaws.serverless.proxy.internal.servlet.AwsProxyHttpServletRequestReader;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashSet;
 import javax.servlet.http.HttpServletRequest;
@@ -104,6 +108,10 @@ public abstract class EnvironmentControllerTestCase {
         .build();
   }
 
+  protected InstanceGroup instanceGroupDS() {
+    return instanceGroupWithAttributeDS(ATTRIBUTE_NAME, ATTRIBUTE_VALUE);
+  }
+
   protected InstanceGroup instanceGroupWithAttributeDS(
       String attributeName, String attributeValue) {
     return InstanceGroup.builder()
@@ -120,5 +128,36 @@ public abstract class EnvironmentControllerTestCase {
 
   protected com.amazonaws.blox.frontend.models.DeploymentConfiguration deploymentConfigurationFE() {
     return com.amazonaws.blox.frontend.models.DeploymentConfiguration.builder().build();
+  }
+
+  protected EnvironmentRevision environmentRevisionDS(
+      final EnvironmentId id, final InstanceGroup instanceGroup) {
+    return environmentRevisionDS(id, TASK_DEFINITION, instanceGroup);
+  }
+
+  protected EnvironmentRevision environmentRevisionDS(
+      final EnvironmentId id, final String taskDefinition, final InstanceGroup instanceGroup) {
+    return EnvironmentRevision.builder()
+        .environmentId(id)
+        .environmentRevisionId(ENVIRONMENT_REVISION_ID)
+        .instanceGroup(instanceGroup)
+        .taskDefinition(taskDefinition)
+        .createdTime(Instant.now())
+        .build();
+  }
+
+  protected Environment environmentDS(
+      final EnvironmentId id, final DeploymentConfiguration deploymentConfiguration) {
+    return Environment.builder()
+        .environmentId(id)
+        .role(ROLE)
+        .environmentType(ENVIRONMENT_TYPE)
+        .environmentHealth(HEALTHY)
+        .environmentStatus(STATUS)
+        .deploymentMethod(DEPLOYMENT_METHOD)
+        .deploymentConfiguration(deploymentConfiguration)
+        .createdTime(Instant.now())
+        .lastUpdatedTime(Instant.now())
+        .build();
   }
 }

--- a/frontend-service/src/test/java/com/amazonaws/blox/frontend/operations/UpdateEnvironmentTest.java
+++ b/frontend-service/src/test/java/com/amazonaws/blox/frontend/operations/UpdateEnvironmentTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox.frontend.operations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentId;
+import com.amazonaws.blox.frontend.mappers.UpdateEnvironmentMapper;
+import com.amazonaws.blox.frontend.operations.UpdateEnvironment.UpdateEnvironmentRequest;
+import com.amazonaws.blox.frontend.operations.UpdateEnvironment.UpdateEnvironmentResponse;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class UpdateEnvironmentTest extends EnvironmentControllerTestCase {
+
+  private static final String NEW_TASK_DEFINITION = "new_task_definition";
+  @Autowired UpdateEnvironment controller;
+  @Autowired UpdateEnvironmentMapper mapper;
+
+  @Test
+  public void mapsInputsAndOutputsCorrectly() throws Exception {
+    EnvironmentId id =
+        EnvironmentId.builder()
+            .accountId(ACCOUNT_ID)
+            .cluster(TEST_CLUSTER)
+            .environmentName(ENVIRONMENT_NAME)
+            .build();
+
+    when(dataService.updateEnvironment(any()))
+        .thenReturn(
+            com.amazonaws.blox.dataservicemodel.v1.model.wrappers.UpdateEnvironmentResponse
+                .builder()
+                .environment(environmentDS(id, deploymentConfigurationDS()))
+                .environmentRevision(
+                    environmentRevisionDS(id, NEW_TASK_DEFINITION, instanceGroupDS()))
+                .build());
+
+    UpdateEnvironmentResponse response =
+        controller.updateEnvironment(
+            TEST_CLUSTER,
+            ENVIRONMENT_NAME,
+            UpdateEnvironmentRequest.builder()
+                .environmentName(ENVIRONMENT_NAME)
+                .taskDefinition(NEW_TASK_DEFINITION)
+                .build());
+
+    verify(dataService)
+        .updateEnvironment(
+            com.amazonaws.blox.dataservicemodel.v1.model.wrappers.UpdateEnvironmentRequest.builder()
+                .environmentId(id)
+                .taskDefinition(NEW_TASK_DEFINITION)
+                .build());
+
+    assertThat(response).isNotNull();
+
+    assertThat(response.getEnvironmentRevisionId()).isEqualTo(ENVIRONMENT_REVISION_ID);
+  }
+}

--- a/integ-tests/src/cucumberTest/java/cucumber/steps/helpers/InputCreator.java
+++ b/integ-tests/src/cucumberTest/java/cucumber/steps/helpers/InputCreator.java
@@ -17,14 +17,12 @@ package cucumber.steps.helpers;
 import com.amazonaws.blox.dataservicemodel.v1.model.Cluster;
 import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentId;
 import com.amazonaws.blox.dataservicemodel.v1.model.EnvironmentType;
-import com.amazonaws.blox.dataservicemodel.v1.model.InstanceGroup;
 import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.CreateEnvironmentRequest;
 import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.DeleteEnvironmentRequest;
 import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.DescribeEnvironmentRequest;
 import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListClustersRequest;
 import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.ListEnvironmentsRequest;
 import com.amazonaws.blox.dataservicemodel.v1.model.wrappers.UpdateEnvironmentRequest;
-import java.util.Collections;
 import java.util.StringJoiner;
 import java.util.UUID;
 import lombok.Getter;
@@ -106,9 +104,7 @@ public class InputCreator {
   private UpdateEnvironmentRequest updateEnvironmentRequest(final EnvironmentId id) {
     return UpdateEnvironmentRequest.builder()
         .environmentId(id)
-        .role(getRoleArn())
         .taskDefinition(getTaskDefinitionArn())
-        .instanceGroup(InstanceGroup.builder().attributes(Collections.emptySet()).build())
         .build();
   }
 


### PR DESCRIPTION
This adds the plumbing for the `updateEnvironment` API call on the Frontend. Since we're not sure how to handle role/instanceGroup updates yet, I've removed those from the DataService API, and omitted them from the frontend.

#### Testing
```
gradle check
```

#### Licensing
This contribution is under the terms of the Apache 2.0 License: Yes
