### PR TITLE
Add end-to-end test for UpdateEnvironment

### DIFF
--- a/end-to-end-tests/src/main/java/com/amazonaws/blox/integ/BloxTestStack.java
+++ b/end-to-end-tests/src/main/java/com/amazonaws/blox/integ/BloxTestStack.java
@@ -62,8 +62,12 @@ public class BloxTestStack {
     return ecs.describeTasks();
   }
 
-  public String getTaskDefinition() {
-    return ecs.getTaskDefinition();
+  public String getTransientTaskDefinition() {
+    return ecs.getTransientTaskDefinition();
+  }
+
+  public String getPersistentTaskDefinition() {
+    return ecs.getPersistentTaskDefinition();
   }
 
   public String getCluster() {

--- a/end-to-end-tests/src/main/java/com/amazonaws/blox/integ/ECSClusterWrapper.java
+++ b/end-to-end-tests/src/main/java/com/amazonaws/blox/integ/ECSClusterWrapper.java
@@ -39,8 +39,12 @@ public class ECSClusterWrapper {
     this(ecs, stacks.get("blox-test-cluster"));
   }
 
-  public String getTaskDefinition() {
-    return stack.output("taskdef");
+  public String getTransientTaskDefinition() {
+    return stack.output("transienttask");
+  }
+
+  public String getPersistentTaskDefinition() {
+    return stack.output("persistenttask");
   }
 
   public String getCluster() {

--- a/end-to-end-tests/src/test/java/com/amazonaws/blox/UpdateDaemonEnvironmentTest.java
+++ b/end-to-end-tests/src/test/java/com/amazonaws/blox/UpdateDaemonEnvironmentTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.blox;
+
+import static com.amazonaws.blox.integ.AsynchronousTestSupport.waitOrTimeout;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.amazonaws.blox.integ.BloxTestStack;
+import com.amazonaws.blox.model.CreateEnvironmentRequest;
+import com.amazonaws.blox.model.DeleteEnvironmentRequest;
+import com.amazonaws.blox.model.DeploymentConfiguration;
+import com.amazonaws.blox.model.StartDeploymentRequest;
+import com.amazonaws.blox.model.UpdateEnvironmentRequest;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class UpdateDaemonEnvironmentTest {
+
+  private static final long RECONCILIATION_INTERVAL = 60_000;
+  private String environmentName;
+  private BloxTestStack stack;
+
+  @Before
+  public void setUp() {
+    final String bloxEndpoint = System.getProperty("blox.tests.apiUrl");
+    stack = new BloxTestStack(bloxEndpoint);
+
+    environmentName = "EndToEndTestEnvironment_" + UUID.randomUUID();
+  }
+
+  @After
+  public void tearDown() {
+    // Delete environment
+    stack
+        .getBlox()
+        .deleteEnvironment(
+            new DeleteEnvironmentRequest()
+                .cluster(stack.getCluster())
+                .environmentName(environmentName));
+
+    // Cleanup ECS tasks
+    stack.reset();
+  }
+
+  @Test
+  public void updatingEnvironmentCreatesNewRevision() throws Exception {
+    // Create environment
+    final Blox blox = stack.getBlox();
+
+    final String firstTaskDefinition = stack.getPersistentTaskDefinition();
+    final String secondTaskDefinition = stack.getTransientTaskDefinition();
+
+    final String firstRevisionId =
+        blox.createEnvironment(
+                new CreateEnvironmentRequest()
+                    .environmentName(environmentName)
+                    .taskDefinition(firstTaskDefinition)
+                    .deploymentConfiguration(new DeploymentConfiguration())
+                    .cluster(stack.getCluster())
+                    .environmentType("Daemon")
+                    .role("Test")
+                    .deploymentMethod("ReplaceAfterTerminate"))
+            .getEnvironmentRevisionId();
+
+    // Now start deployment
+    blox.startDeployment(
+        new StartDeploymentRequest()
+            .cluster(stack.getCluster())
+            .environmentName(environmentName)
+            .revisionId(firstRevisionId));
+
+    waitOrTimeout(
+        RECONCILIATION_INTERVAL * 3 / 2,
+        () -> {
+          assertThat(stack.describeTasks())
+              .as("Tasks launched by blox")
+              .allSatisfy(
+                  t ->
+                      assertThat(t)
+                          .hasFieldOrPropertyWithValue("group", environmentName)
+                          .hasFieldOrPropertyWithValue("taskDefinitionArn", firstTaskDefinition));
+        });
+
+    final String secondRevisionId =
+        blox.updateEnvironment(
+                new UpdateEnvironmentRequest()
+                    .cluster(stack.getCluster())
+                    .environmentName(environmentName)
+                    .taskDefinition(secondTaskDefinition))
+            .getEnvironmentRevisionId();
+
+    blox.startDeployment(
+        new StartDeploymentRequest()
+            .cluster(stack.getCluster())
+            .environmentName(environmentName)
+            .revisionId(firstRevisionId));
+
+    waitOrTimeout(
+        RECONCILIATION_INTERVAL * 3 / 2,
+        () -> {
+          assertThat(stack.describeTasks())
+              .as("Tasks launched by blox")
+              .allSatisfy(
+                  t ->
+                      assertThat(t)
+                          .hasFieldOrPropertyWithValue("group", environmentName)
+                          .hasFieldOrPropertyWithValue("taskDefinitionArn", secondTaskDefinition));
+        });
+  }
+}

--- a/end-to-end-tests/templates/test_cluster.yml
+++ b/end-to-end-tests/templates/test_cluster.yml
@@ -3,7 +3,7 @@ AWSTemplateFormatVersion: '2010-09-09'
 Parameters:
   DesiredInstances:
     Type: Number
-    Default: '1'
+    Default: '2'
     Description: Number of instances to launch in your ECS cluster.
   DesiredTasks:
     Type: Number
@@ -12,27 +12,27 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: m3.medium
+    Default: t2.micro
 Mappings:
   AWSRegionToAMI:
     us-east-1:
-      AMIID: ami-eca289fb
+      AMIID: ami-5e414e24
     us-east-2:
-      AMIID: ami-446f3521
+      AMIID: ami-67ab9e02
     us-west-1:
-      AMIID: ami-9fadf8ff
+      AMIID: ami-00898660
     us-west-2:
-      AMIID: ami-7abc111a
+      AMIID: ami-10ed6968
     eu-west-1:
-      AMIID: ami-a1491ad2
+      AMIID: ami-880d64f1
     eu-central-1:
-      AMIID: ami-54f5303b
+      AMIID: ami-63cbae0c
     ap-northeast-1:
-      AMIID: ami-9cd57ffd
+      AMIID: ami-e3166185
     ap-southeast-1:
-      AMIID: ami-a900a3ca
+      AMIID: ami-66c98f1a
     ap-southeast-2:
-      AMIID: ami-5781be34
+      AMIID: ami-36867d54
 Resources:
   Cluster:
     Type: AWS::ECS::Cluster
@@ -40,11 +40,11 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: ECS Security Group
-  SleepTask:
+  TransientTask:
     Type: AWS::ECS::TaskDefinition
     Properties:
       Family:
-        Fn::Join: ['', [{ Ref: 'AWS::StackName' }, -task]]
+        Fn::Join: ['', [{ Ref: 'AWS::StackName' }, -transient-task]]
       ContainerDefinitions:
       - Name: sleep
         Cpu: '10'
@@ -52,6 +52,21 @@ Resources:
         Essential: 'true'
         Image: 'alpine:latest'
         Command: ['/bin/sh', '-c', 'sleep $TIME']
+        Environment:
+        - Name: TIME
+          Value: "60"
+  PersistentTask:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family:
+        Fn::Join: ['', [{ Ref: 'AWS::StackName' }, -persistent-task]]
+      ContainerDefinitions:
+      - Name: sleep
+        Cpu: '10'
+        Memory: '300'
+        Essential: 'true'
+        Image: 'alpine:latest'
+        Command: ['/bin/sh', '-c', 'trap : TERM INT; sleep infinity & wait']
         Environment:
         - Name: TIME
           Value: "60"
@@ -130,5 +145,7 @@ Resources:
 Outputs:
   cluster:
     Value: { Ref: 'Cluster' }
-  taskdef:
-    Value: { Ref: 'SleepTask' }
+  transienttask:
+    Value: { Ref: 'TransientTask' }
+  persistenttask:
+    Value: { Ref: 'PersistentTask' }

--- a/frontend-service-client/src/main/java/com/amazonaws/blox/model/transform/UpdateEnvironmentRequestMarshaller.java
+++ b/frontend-service-client/src/main/java/com/amazonaws/blox/model/transform/UpdateEnvironmentRequestMarshaller.java
@@ -21,7 +21,7 @@ public class UpdateEnvironmentRequestMarshaller {
     private static final MarshallingInfo<String> CLUSTER_BINDING = MarshallingInfo.builder(MarshallingType.STRING).marshallLocation(MarshallLocation.PATH)
             .marshallLocationName("cluster").build();
     private static final MarshallingInfo<String> ENVIRONMENTNAME_BINDING = MarshallingInfo.builder(MarshallingType.STRING)
-            .marshallLocation(MarshallLocation.PAYLOAD).marshallLocationName("environmentName").build();
+            .marshallLocation(MarshallLocation.PATH).marshallLocationName("environmentName").build();
     private static final MarshallingInfo<String> TASKDEFINITION_BINDING = MarshallingInfo.builder(MarshallingType.STRING)
             .marshallLocation(MarshallLocation.PAYLOAD).marshallLocationName("taskDefinition").build();
 

--- a/frontend-service/api/swagger.yml
+++ b/frontend-service/api/swagger.yml
@@ -518,8 +518,6 @@ definitions:
   UpdateEnvironmentRequest:
     type: "object"
     properties:
-      environmentName:
-        type: "string"
       taskDefinition:
         type: "string"
   UpdateEnvironmentResponse:

--- a/frontend-service/src/main/java/com/amazonaws/blox/frontend/mappers/UpdateEnvironmentMapper.java
+++ b/frontend-service/src/main/java/com/amazonaws/blox/frontend/mappers/UpdateEnvironmentMapper.java
@@ -25,7 +25,7 @@ import org.mapstruct.Mapping;
 public interface UpdateEnvironmentMapper {
   @Mapping(target = "environmentId.accountId", source = "context.accountId")
   @Mapping(target = "environmentId.cluster", source = "cluster")
-  @Mapping(target = "environmentId.environmentName", source = "request.environmentName")
+  @Mapping(target = "environmentId.environmentName", source = "environmentName")
   UpdateEnvironmentRequest toDataServiceRequest(
       ApiGatewayRequestContext context,
       String cluster,

--- a/frontend-service/src/main/java/com/amazonaws/blox/frontend/operations/UpdateEnvironment.java
+++ b/frontend-service/src/main/java/com/amazonaws/blox/frontend/operations/UpdateEnvironment.java
@@ -67,7 +67,6 @@ public class UpdateEnvironment extends EnvironmentController {
   @AllArgsConstructor
   @NoArgsConstructor
   public static class UpdateEnvironmentRequest {
-    private String environmentName;
     private String taskDefinition;
   }
 }

--- a/frontend-service/src/test/java/com/amazonaws/blox/frontend/operations/UpdateEnvironmentTest.java
+++ b/frontend-service/src/test/java/com/amazonaws/blox/frontend/operations/UpdateEnvironmentTest.java
@@ -52,10 +52,7 @@ public class UpdateEnvironmentTest extends EnvironmentControllerTestCase {
         controller.updateEnvironment(
             TEST_CLUSTER,
             ENVIRONMENT_NAME,
-            UpdateEnvironmentRequest.builder()
-                .environmentName(ENVIRONMENT_NAME)
-                .taskDefinition(NEW_TASK_DEFINITION)
-                .build());
+            UpdateEnvironmentRequest.builder().taskDefinition(NEW_TASK_DEFINITION).build());
 
     verify(dataService)
         .updateEnvironment(


### PR DESCRIPTION
#### Summary
The main goal of this PR is to add an end-to-end test for UpdateEnvironment.


#### Implementation details
Apart from adding the new test case, this also fixes the following issues that was preventing the end-to-end test from working:
- fix an FE bug where `environmentName` was present in both the URI path and the request body of `updateEnvironment`
- the test cluster now has multiple instances, and the tests verify that tasks are started on all of them
- the test stack has an additional task definition, so that we can change task definitions

#### Testing
```
gradle testEndToEnd
```
#### Licensing
This contribution is under the terms of the Apache 2.0 License: Yes
