### PR TITLE
Add copy task for build outputs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ description "Blox: Open Source schedulers for Amazon ECS"
 
 allprojects {
     apply plugin: 'com.diffplug.gradle.spotless'
-
     group 'com.amazonaws.blox'
     version '0.1-SNAPSHOT'
 
@@ -228,3 +227,24 @@ task updateClient(type: Copy, dependsOn: downloadClient) {
         file("${tmpDir}/generated-code").renameTo(file("frontend-service-client"))
     }
 }
+task release
+
+def projectsToRelease = ["frontend-service", "data-service", "scheduling-manager"].collect { project(it) }
+configure(projectsToRelease) {
+    task release(dependsOn: assemble) {
+        group "build"
+        description "Build the project and copy the outputs required for the pipeline"
+        doLast {
+            copy {
+                from tasks.getByPath("packageLambda")
+                from tasks.getByPath("postprocessCloudformationTemplate")
+
+                into rootProject.file("build/blox-release/${project.name}")
+            }
+        }
+    }
+
+    rootProject.release.dependsOn(release)
+}
+
+

--- a/buildSrc/src/main/groovy/com/amazonaws/blox/deployment/DeploymentPlugin.groovy
+++ b/buildSrc/src/main/groovy/com/amazonaws/blox/deployment/DeploymentPlugin.groovy
@@ -44,6 +44,7 @@ class DeploymentPlugin implements Plugin<Project> {
                 lambdaFunction it.name, project.files(it.zipFile)
             }
         }
+        project.assemble.dependsOn(postProcessTask)
 
 
         def packageTask = project.task("packageCloudformationResources", type: Exec) {

--- a/data-service/build.gradle
+++ b/data-service/build.gradle
@@ -81,6 +81,8 @@ task packageLambda(type: Zip, dependsOn: classes) {
     }
 }
 
+assemble.dependsOn(packageLambda)
+
 deployment {
     aws {
         profile stack.profile.toString()

--- a/frontend-service/build.gradle
+++ b/frontend-service/build.gradle
@@ -88,6 +88,7 @@ task packageLambda(type: Zip, dependsOn: classes) {
         from configurations.runtime
     }
 }
+assemble.dependsOn(packageLambda)
 
 deployment {
     aws {

--- a/scheduling-manager/build.gradle
+++ b/scheduling-manager/build.gradle
@@ -61,6 +61,7 @@ task packageLambda(type: Zip) {
         from configurations.runtime
     }
 }
+assemble.dependsOn(packageLambda)
 
 deployment {
     aws {


### PR DESCRIPTION
#### Summary
Add copy task for build outputs

#### Implementation details
<!-- How are the changes implemented? -->

#### Testing
bb release on the brazil directory
Output copied to:
${Brazil_workspace_root}/build/blox-release

#### Licensing
This contribution is under the terms of the Apache 2.0 License: Yes
